### PR TITLE
display µc programming like a sign

### DIFF
--- a/mesecons_microcontroller/init.lua
+++ b/mesecons_microcontroller/init.lua
@@ -142,9 +142,9 @@ function update_yc(pos)
 	code = string.gsub(code, " ", "")	--Remove all spaces
 	code = string.gsub(code, "	", "")	--Remove all tabs
 	if yc_parsecode(code, pos) == nil then
-		meta:set_string("infotext", "Code not valid!")
+		meta:set_string("infotext", "Code not valid!\n"..code)
 	else
-		meta:set_string("infotext", "Working Microcontroller")
+		meta:set_string("infotext", "Working Microcontroller\n"..code)
 	end
 end
 


### PR DESCRIPTION
I had a grid that mapped buttons to pixels so pressing a button displayed a letter. I had one programming that was a positive match so the pixel turned on, and another programming that was negative and just passed the signal on to the next pixel. If I had to right-click on each µc to see its programming, it would take me longer to find a problem. If I can see the programming just by looking at it, I could find a typo much easier.
I'm not sure about the \n \n\r thing.
