### PR TITLE
fix t-junction selectionbox when on

### DIFF
--- a/mesecons_extrawires/tjunction.lua
+++ b/mesecons_extrawires/tjunction.lua
@@ -6,8 +6,8 @@ local tjunction_nodebox = {
 
 local tjunction_selectionbox = {
 		type = "fixed",
-		fixed = { -16/32-0.001, -18/32, -16/32, 16/32+0.001, -12/32, 7/32 }
-},
+		fixed = { -16/32-0.001, -18/32, -16/32, 16/32+0.001, -12/32, 7/32 },
+}
 
 minetest.register_node("mesecons_extrawires:tjunction_on", {
 	drawtype = "nodebox",


### PR DESCRIPTION
The selectionbox was correct when the t-junction was off, but it was node-sized when the t-junction was on. A misplaced comma was the cause.
