### PR TITLE
Electrically conductive ghoststone

### DIFF
--- a/mesecons_random/init.lua
+++ b/mesecons_random/init.lua
@@ -31,10 +31,17 @@ minetest.register_node("mesecons_random:ghoststone", {
 	inventory_image = minetest.inventorycube("jeija_ghoststone_inv.png"),
 	groups = {cracky=3},
 	sounds = default.node_sound_stone_defaults(),
-	mesecons = {effector = {
-		action_on = function (pos, node)
-			minetest.env:add_node(pos, {name="mesecons_random:ghoststone_active"})
-		end
+	mesecons = {conductor = {
+		state = mesecon.state.off,
+		rules = { --axes
+			{x = -1, y = 0, z = 0},
+			{x = 1, y = 0, z = 0},
+			{x = 0, y = -1, z = 0},
+			{x = 0, y = 1, z = 0},
+			{x = 0, y = 0, z = -1},
+			{x = 0, y = 0, z = 1},
+		},
+		onstate = "mesecons_random:ghoststone_active"
 	}}
 })
 
@@ -44,10 +51,17 @@ minetest.register_node("mesecons_random:ghoststone_active", {
 	walkable = false,
 	diggable = false,
 	sunlight_propagates = true,
-	mesecons = {effector = {
-		action_off = function (pos, node)
-			minetest.env:add_node(pos, {name="mesecons_random:ghoststone"})
-		end
+	mesecons = {conductor = {
+		state = mesecon.state.on,
+		rules = {
+			{x = -1, y = 0, z = 0},
+			{x = 1, y = 0, z = 0},
+			{x = 0, y = -1, z = 0},
+			{x = 0, y = 1, z = 0},
+			{x = 0, y = 0, z = -1},
+			{x = 0, y = 0, z = 1},
+		},
+		offstate = "mesecons_random:ghoststone"
 	}}
 })
 


### PR DESCRIPTION
I was making a mesecon machine, and I wanted to make a case for it that could be removed by a switch without having a wire covering and without using worldedit and without using a piston system and without fire.
A wall of ghoststone with a single power source would work just fine.
Now, as to whether original ghoststone would still exist, I ask you this: Is there a good reason to have nonconductive ghoststone? - should electric ghoststone be a separate node?
I will now work on [time goes by] I now give you a patch.
If this were an issue, it would be marked as Enhancement.
