### PR TITLE
Remove ghoststone_active shadow on_construct

### DIFF
--- a/mesecons_random/init.lua
+++ b/mesecons_random/init.lua
@@ -51,6 +51,7 @@ minetest.register_node("mesecons_random:ghoststone_active", {
 	walkable = false,
 	diggable = false,
 	sunlight_propagates = true,
+	paramtype = "light",
 	mesecons = {conductor = {
 		state = mesecon.state.on,
 		rules = {
@@ -62,7 +63,14 @@ minetest.register_node("mesecons_random:ghoststone_active", {
 			{x = 0, y = 0, z = 1},
 		},
 		offstate = "mesecons_random:ghoststone"
-	}}
+	}},
+	on_construct = function(pos)
+		--remove shadow
+		pos2 = {x = pos.x, y = pos.y + 1, z = pos.z}
+		if ( minetest.env:get_node(pos2).name == "air" ) then
+			minetest.env:dig_node(pos2)
+		end
+	end
 })
 
 


### PR DESCRIPTION
…continued from episode https://github.com/Jeija/minetest-mod-mesecons/issues/72.
![minetestghostshadow6](https://f.cloud.github.com/assets/1996449/141175/0e6889a8-723d-11e2-87f5-18b4d2678e01.png)
This approximately copies some worldedit code that makes ghoststone dig neighbor air nodes when turned active. 
![minetestghostshadow7](https://f.cloud.github.com/assets/1996449/141176/12ac1098-723d-11e2-9fa6-8bfae1cc7ce4.png)
Can you find a better way of making an invisible node leave no shadow?
