### PR TITLE
Texture tweaks for vertical wires with caps

### DIFF
--- a/mesecons_extrawires/vertical.lua
+++ b/mesecons_extrawires/vertical.lua
@@ -117,7 +117,7 @@ minetest.register_node("mesecons_extrawires:vertical_off", {
 minetest.register_node("mesecons_extrawires:vertical_top_on", {
 	description = "Vertical mesecon",
 	drawtype = "nodebox",
-	tiles = {"wires_full_on.png"},
+	tiles = {"wires_full_on.png","wires_full_on.png","wires_vertical_on.png"},
 	walkable = false,
 	paramtype = "light",
 	sunlight_propagates = true,
@@ -139,7 +139,7 @@ minetest.register_node("mesecons_extrawires:vertical_top_on", {
 minetest.register_node("mesecons_extrawires:vertical_top_off", {
 	description = "Vertical mesecon",
 	drawtype = "nodebox",
-	tiles = {"wires_full_off.png"},
+	tiles = {"wires_full_off.png","wires_full_off.png","wires_vertical_off.png"},
 	walkable = false,
 	paramtype = "light",
 	sunlight_propagates = true,
@@ -162,7 +162,7 @@ minetest.register_node("mesecons_extrawires:vertical_top_off", {
 minetest.register_node("mesecons_extrawires:vertical_bottom_on", {
 	description = "Vertical mesecon",
 	drawtype = "nodebox",
-	tiles = {"wires_full_on.png"},
+	tiles = {"wires_full_on.png","wires_full_on.png","wires_vertical_on.png"},
 	walkable = false,
 	paramtype = "light",
 	sunlight_propagates = true,
@@ -183,7 +183,7 @@ minetest.register_node("mesecons_extrawires:vertical_bottom_on", {
 minetest.register_node("mesecons_extrawires:vertical_bottom_off", {
 	description = "Vertical mesecon",
 	drawtype = "nodebox",
-	tiles = {"wires_full_off.png"},
+	tiles = {"wires_full_off.png","wires_full_off.png","wires_vertical_off.png"},
 	walkable = false,
 	paramtype = "light",
 	sunlight_propagates = true,


### PR DESCRIPTION
Allow vertical wires with caps to use the "vertical" texture for the sides (still uses the "full" for the top/bottom of the caps).
