### PR TITLE
Change mesecons signals so that they update effectors only after a globalstep

### DIFF
--- a/mesecons/init.lua
+++ b/mesecons/init.lua
@@ -49,6 +49,10 @@ mesecon.receptors={} --  saves all information about receptors  | DEPRECATED
 mesecon.effectors={} --  saves all information about effectors  | DEPRECATED
 mesecon.conductors={} -- saves all information about conductors | DEPRECATED
 
+
+mesecon.to_update = {}
+mesecon.r_to_update = {}
+
 -- Settings
 dofile(minetest.get_modpath("mesecons").."/settings.lua")
 
@@ -76,7 +80,7 @@ dofile(minetest.get_modpath("mesecons").."/legacy.lua");
 -- API
 -- these are the only functions you need to remember
 
-function mesecon:receptor_on(pos, rules)
+function mesecon:receptor_on_i(pos, rules)
 	rules = rules or mesecon.rules.default
 
 	for _, rule in ipairs(rules) do
@@ -88,7 +92,12 @@ function mesecon:receptor_on(pos, rules)
 	end
 end
 
-function mesecon:receptor_off(pos, rules)
+function mesecon:receptor_on(pos, rules)
+	rules = rules or mesecon.rules.default
+	mesecon.r_to_update[#mesecon.r_to_update+1]={pos=pos, rules=rules, action="on"}
+end
+
+function mesecon:receptor_off_i(pos, rules)
 	rules = rules or mesecon.rules.default
 
 	for _, rule in ipairs(rules) do
@@ -102,6 +111,11 @@ function mesecon:receptor_off(pos, rules)
 			end
 		end
 	end
+end
+
+function mesecon:receptor_off(pos, rules)
+	rules = rules or mesecon.rules.default
+	mesecon.r_to_update[#mesecon.r_to_update+1]={pos=pos, rules=rules, action="off"}
 end
 
 

--- a/mesecons/internal.lua
+++ b/mesecons/internal.lua
@@ -180,24 +180,111 @@ end
 --Signals
 
 function mesecon:activate(pos, node, rulename)
-	local effector = mesecon:get_effector(node.name)
-	if effector and effector.action_on then
-		effector.action_on (pos, node, rulename)
+	if rulename == nil then
+		for _,rule in ipairs(mesecon:effector_get_rules(node)) do
+			mesecon:activate(pos, node, rule)
+		end
+		return
+	end
+	if MESECONS_GLOBALSTEP then
+		add_action(pos, "on", rulename)
+	else
+		local effector = mesecon:get_effector(node.name)
+		if effector and effector.action_on then
+			effector.action_on (pos, node, rulename)
+		end
 	end
 end
 
 function mesecon:deactivate(pos, node, rulename)
-	local effector = mesecon:get_effector(node.name)
-	if effector and effector.action_off then
-		effector.action_off (pos, node, rulename)
+	if rulename == nil then
+		for _,rule in ipairs(mesecon:effector_get_rules(node)) do
+			mesecon:deactivate(pos, node, rule)
+		end
+		return
+	end
+	if MESECONS_GLOBALSTEP then
+		add_action(pos, "off", rulename)
+	else
+		local effector = mesecon:get_effector(node.name)
+		if effector and effector.action_off then
+			effector.action_off (pos, node, rulename)
+		end
 	end
 end
 
 function mesecon:changesignal(pos, node, rulename, newstate)
-	local effector = mesecon:get_effector(node.name)
-	if effector and effector.action_change then
-		effector.action_change (pos, node, rulename, newstate)
+	
+	newstate = newstate or "on"
+	--rulename = rulename or mesecon.rules.default
+	if rulename == nil then
+		for _,rule in ipairs(mesecon:effector_get_rules(node)) do
+			mesecon:changesignal(pos, node, rule, newstate)
+		end
+		return
 	end
+	if MESECONS_GLOBALSTEP then
+		add_action(pos, "c"..newstate, rulename)
+	else
+		local effector = mesecon:get_effector(node.name)
+		if effector and effector.action_change then
+			effector.action_change (pos, node, rulename, newstate)
+		end
+	end
+end
+
+function execute_actions(dtime)
+	local nactions = mesecon.to_update
+	mesecon.to_update = {}
+	for _,i in ipairs(nactions) do
+		node = minetest.env:get_node(i.pos)
+		effector = mesecon:get_effector(node.name)
+		if i.action == "on" then
+			if effector and effector.action_on then
+				effector.action_on(i.pos, node, i.rname)
+			end
+		elseif i.action == "off" then
+			if effector and effector.action_off then
+				effector.action_off(i.pos, node, i.rname)
+			end
+		elseif i.action == "con" then
+			if effector and effector.action_change then
+				effector.action_change(i.pos, node, i.rname, "on")
+			end
+		elseif i.action == "coff" then
+			if effector and effector.action_change then
+				effector.action_change(i.pos, node, i.rname, "off")
+			end
+		end
+	end
+	local nactions = mesecon.r_to_update
+	mesecon.r_to_update = {}
+	for _,i in ipairs(nactions) do
+		if i.action == "on" then
+			mesecon:receptor_on_i(i.pos, i.rules)
+		else
+			mesecon:receptor_off_i(i.pos,i.rules)
+		end
+	end
+end
+
+minetest.register_globalstep(execute_actions)
+
+function add_action(pos, action, rname)
+	for _,i in ipairs(mesecon.to_update) do
+		if i.pos.x == pos.x and i.pos.y == pos.y and i.pos.z == pos.z and i.rname.x == rname.x and i.rname.y == rname.y and i.rname.z == rname.z then
+			if (i.action == "on" and action == "on") or (i.action == "off" and action == "off") then
+				--nothing
+			elseif i.action == "coff" and action == "on" then i.action = "on"
+			elseif i.action == "con" and action == "off" then i.action = "off"
+			else
+				if action == "on" or action == "con" then i.action = "con" end
+				if action == "off" or action == "coff" then i.action = "coff" end
+			end
+			break
+		end
+	end
+	mesecon.to_update[#mesecon.to_update+1] = {pos = pos, action = action, rname = rname}
 end
 
 --Rules

--- a/mesecons/services.lua
+++ b/mesecons/services.lua
@@ -1,5 +1,4 @@
-mesecon.on_placenode = function (pos)
-	local node = minetest.env:get_node(pos)
+mesecon.on_placenode = function (pos, node)
 	if mesecon:is_receptor_on(node.name) then
 		mesecon:receptor_on(pos, mesecon:receptor_get_rules(node))
 	elseif mesecon:is_powered(pos) then
@@ -7,7 +6,7 @@ mesecon.on_placenode = function (pos)
 			mesecon:turnon (pos)
 			mesecon:receptor_on (pos, mesecon:conductor_get_rules(node))
 		else
-			mesecon:changesignal(pos, node)
+			mesecon:changesignal(pos, node, mesecon:effector_get_rules(node), "on")
 			mesecon:activate(pos, node)
 		end
 	elseif mesecon:is_conductor_on(node.name) then

--- a/mesecons/settings.lua
+++ b/mesecons/settings.lua
@@ -5,3 +5,5 @@ PRESSURE_PLATE_INTERVAL = 0.1
 OBJECT_DETECTOR_RADIUS = 6
 PISTON_MAXIMUM_PUSH = 15
 MOVESTONE_MAXIMUM_PUSH = 100
+MESECONS_GLOBALSTE = true	-- true = receptors/effectors won't be updated
+				-- until next globalstep, decreases server load


### PR DESCRIPTION
It decreases server load, and is configurable to be on/off. It moreover allows pipelined circuits and precise timings, which were not possible before.
