### PR TITLE
Handle luacontroller formspec events correctly

### DIFF
--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -518,7 +518,7 @@ minetest.register_node(nodename, {
 	node_box = nodebox,
 	on_construct = reset_meta,
 	on_receive_fields = function(pos, formname, fields)
-		if fields.quit then
+		if not fields.program then
 			return
 		end
 		reset(pos)


### PR DESCRIPTION
Example of problem fixed by this: Edit lua code, press Execute. Now
(execute button has focus), hold down a key. Zillions of "program"
events are generated.
