### PR TITLE
Fix the commandblock's check for quiting the formspec

### DIFF
--- a/mesecons_commandblock/init.lua
+++ b/mesecons_commandblock/init.lua
@@ -79,7 +79,7 @@ local function after_place(pos, placer)
 end
 
 local function receive_fields(pos, formname, fields, sender)
-	if fields.quit then
+	if not fields.submit then
 		return
 	end
 	local meta = minetest.get_meta(pos)


### PR DESCRIPTION
The submit button also sends a quit field.
