### PR TITLE
Add cornernote's 'craft_guide' mod as optional dependency:

### DIFF
--- a/mesecons_blinkyplant/depends.txt
+++ b/mesecons_blinkyplant/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/mesecons_button/depends.txt
+++ b/mesecons_button/depends.txt
@@ -1,2 +1,3 @@
 mesecons
 mesecons_receiver
+craft_guide?

--- a/mesecons_delayer/depends.txt
+++ b/mesecons_delayer/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/mesecons_detector/depends.txt
+++ b/mesecons_detector/depends.txt
@@ -1,2 +1,3 @@
 mesecons
 mesecons_materials
+craft_guide?

--- a/mesecons_extrawires/depends.txt
+++ b/mesecons_extrawires/depends.txt
@@ -1,2 +1,3 @@
 default
 mesecons
+craft_guide?

--- a/mesecons_fpga/depends.txt
+++ b/mesecons_fpga/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/mesecons_gates/depends.txt
+++ b/mesecons_gates/depends.txt
@@ -4,3 +4,4 @@ mesecons_delayer
 
 mesecons_torch
 mesecons_materials
+craft_guide?

--- a/mesecons_hydroturbine/depends.txt
+++ b/mesecons_hydroturbine/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/mesecons_insulated/depends.txt
+++ b/mesecons_insulated/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/mesecons_lamp/depends.txt
+++ b/mesecons_lamp/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/mesecons_lightstone/depends.txt
+++ b/mesecons_lightstone/depends.txt
@@ -1,2 +1,3 @@
 mesecons
 dye
+craft_guide?

--- a/mesecons_luacontroller/depends.txt
+++ b/mesecons_luacontroller/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/mesecons_materials/depends.txt
+++ b/mesecons_materials/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/mesecons_microcontroller/depends.txt
+++ b/mesecons_microcontroller/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/mesecons_movestones/depends.txt
+++ b/mesecons_movestones/depends.txt
@@ -1,3 +1,4 @@
 mesecons
 mesecons_materials
 mesecons_mvps
+craft_guide?

--- a/mesecons_noteblock/depends.txt
+++ b/mesecons_noteblock/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/mesecons_pistons/depends.txt
+++ b/mesecons_pistons/depends.txt
@@ -1,2 +1,3 @@
 mesecons
 mesecons_mvps
+craft_guide?

--- a/mesecons_powerplant/depends.txt
+++ b/mesecons_powerplant/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/mesecons_pressureplates/depends.txt
+++ b/mesecons_pressureplates/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/mesecons_random/depends.txt
+++ b/mesecons_random/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/mesecons_solarpanel/depends.txt
+++ b/mesecons_solarpanel/depends.txt
@@ -1,2 +1,3 @@
 mesecons
 mesecons_materials
+craft_guide?

--- a/mesecons_switch/depends.txt
+++ b/mesecons_switch/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/mesecons_torch/depends.txt
+++ b/mesecons_torch/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?

--- a/mesecons_walllever/depends.txt
+++ b/mesecons_walllever/depends.txt
@@ -1,2 +1,3 @@
 mesecons
 mesecons_receiver
+craft_guide?

--- a/mesecons_wires/depends.txt
+++ b/mesecons_wires/depends.txt
@@ -1,1 +1,2 @@
 mesecons
+craft_guide?


### PR DESCRIPTION
Ensures that craft recipes are registered in [cornernote's *craft_guide* mod](http://cornernote.github.io/minetest-craft_guide/).

Added to the following mods with craft recipes:
- blinkyplant
- button
- delayer
- detector
- extrawires
- fpga
- gates
- hydroturbine
- insulated
- lamp
- lightstone
- luacontroller
- materials
- microcontroller
- movestones
- noteblock
- pistons
- powerplant
- pressureplates
- random
- solarpanel
- switch
- torch
- walllever
- wires