### PR TITLE
Replace deprecated methods:

### DIFF
--- a/mesecons/settings.lua
+++ b/mesecons/settings.lua
@@ -1,15 +1,15 @@
 -- SETTINGS
 function mesecon.setting(setting, default)
 	if type(default) == "boolean" then
-		local read = minetest.setting_getbool("mesecon."..setting)
+		local read = minetest.settings:get_bool("mesecon."..setting)
 		if read == nil then
 			return default
 		else
 			return read
 		end
 	elseif type(default) == "string" then
-		return minetest.setting_get("mesecon."..setting) or default
+		return minetest.settings:get("mesecon."..setting) or default
 	elseif type(default) == "number" then
-		return tonumber(minetest.setting_get("mesecon."..setting) or default)
+		return tonumber(minetest.settings:get("mesecon."..setting) or default)
 	end
 end


### PR DESCRIPTION
- 'setting_get' with 'settings:get'
- 'setting_getbool' with 'settings:get_bool'

May not want to merge this until after 0.4.16 release, as the new ['settings' object calls][l_settings] are not available in 0.4.15.

[l_settings]: https://github.com/minetest/minetest/blob/43d1f375d18a2fbc547a9b4f23d1354d645856ca/src/script/lua_api/l_settings.cpp#L267