### PR TITLE
Changed Microcontroller and LuaController recipes

### DIFF
--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -678,6 +678,15 @@ minetest.register_node(BASENAME .. "_burnt", {
 minetest.register_craft({
 	output = BASENAME.."0000 2",
 	recipe = {
+		{'mesecons_microcontroller:microcontroller0000', 'mesecons_microcontroller:microcontroller0000', 'mesecons_microcontroller:microcontroller0000'},
+		{'', '', ''},
+		{'', '', ''},
+	}
+})
+
+minetest.register_craft({
+	output = BASENAME.."0000 2",
+	recipe = {
 		{'mesecons_materials:silicon', 'mesecons_materials:silicon', 'group:mesecon_conductor_craftable'},
 		{'mesecons_materials:silicon', 'mesecons_materials:silicon', 'group:mesecon_conductor_craftable'},
 		{'group:mesecon_conductor_craftable', 'group:mesecon_conductor_craftable', ''},

--- a/mesecons_microcontroller/init.lua
+++ b/mesecons_microcontroller/init.lua
@@ -148,8 +148,8 @@ minetest.register_craft({
 	output = 'craft "mesecons_microcontroller:microcontroller0000" 2',
 	recipe = {
 		{'mesecons_materials:silicon', 'mesecons_materials:silicon', 'group:mesecon_conductor_craftable'},
-		{'mesecons_materials:silicon', 'mesecons_materials:silicon', 'group:mesecon_conductor_craftable'},
-		{'group:mesecon_conductor_craftable', 'group:mesecon_conductor_craftable', ''},
+		{'mesecons_materials:silicon', 'group:mesecon_conductor_craftable', 'group:mesecon_conductor_craftable'},
+		{'', '', ''},
 	}
 })
 


### PR DESCRIPTION
Since I've recently ran into the problem described in #339 I decided to take a crack at it. Only minor changes to recipes and an new recipe was added (so as not to waste any items).

---

This commit changes the recipes for the Microcontroller and LuaController.

The Microcontroller is slightly simplifyed, so it no longer masks the recipe
for the LuaController (which otherwise remains unchanged); now both objects
can be crafted freely.

**addendum** recipe for the microcontroller is now:

~~~
[silicon] [silicon] [mesecon]
[silicon] [mesecon] [mesecon]
[       ] [       ] [       ]
~~~

New: A new LuaController recipe, by using 3x Microcontroller parts in the top
row will also produce two LuaControllers.

**addendum**

~~~
[microcontroller] [microcontroller] [microcontroller]
[               ] [               ] [               ]
[               ] [               ] [               ]
~~~

See also: minetest-mods/mesecons#339