### PR TITLE
Recipe change

### DIFF
--- a/mesecons_microcontroller/init.lua
+++ b/mesecons_microcontroller/init.lua
@@ -148,7 +148,7 @@ minetest.register_craft({
 	output = 'craft "mesecons_microcontroller:microcontroller0000" 2',
 	recipe = {
 		{'mesecons_materials:silicon', 'mesecons_materials:silicon', 'group:mesecon_conductor_craftable'},
-		{'mesecons_materials:silicon', 'mesecons_materials:silicon', 'group:mesecon_conductor_craftable'},
+		{'group:mesecon_conductor_craftable', 'group:mesecon_conductor_craftable', 'group:mesecon_conductor_craftable'},
 		{'group:mesecon_conductor_craftable', 'group:mesecon_conductor_craftable', ''},
 	}
 })


### PR DESCRIPTION
Change recipe to allow players to build both the lua and micro controllers.
Currently the recipe is duplicated between two devices making it impossible for players to make the lua controller
This change replaces the second row of silicon with mesecon_conductors.