### PR TITLE
Craft fallbacks for detectors without luacontroller enabled

### DIFF
--- a/mesecons_detector/init.lua
+++ b/mesecons_detector/init.lua
@@ -99,14 +99,25 @@ minetest.register_node("mesecons_detector:object_detector_on", {
 	on_blast = mesecon.on_blastnode,
 })
 
-minetest.register_craft({
-	output = 'mesecons_detector:object_detector_off',
-	recipe = {
-		{"default:steel_ingot", "default:steel_ingot", "default:steel_ingot"},
-		{"default:steel_ingot", "mesecons_luacontroller:luacontroller0000", "default:steel_ingot"},
-		{"default:steel_ingot", "group:mesecon_conductor_craftable", "default:steel_ingot"},
-	}
-})
+if minetest.get_modpath("mesecons_luacontroller") then    
+	minetest.register_craft({
+		output = 'mesecons_detector:object_detector_off',
+		recipe = {
+			{"default:steel_ingot", "default:steel_ingot", "default:steel_ingot"},
+			{"default:steel_ingot", "mesecons_luacontroller:luacontroller0000", "default:steel_ingot"},
+			{"default:steel_ingot", "group:mesecon_conductor_craftable", "default:steel_ingot"},
+		}
+	})
+else
+	minetest.register_craft({
+		output = 'mesecons_detector:object_detector_off',
+		recipe = {
+			{"default:steel_ingot", "default:steel_ingot", "default:steel_ingot"},
+			{"default:steel_ingot", "mesecons_microcontroller:microcontroller0000", "default:steel_ingot"},
+			{"default:steel_ingot", "group:mesecon_conductor_craftable", "default:steel_ingot"},
+		}
+	})
+end
 
 minetest.register_abm({
 	nodenames = {"mesecons_detector:object_detector_off"},
@@ -261,14 +272,25 @@ minetest.register_node("mesecons_detector:node_detector_on", {
 	on_blast = mesecon.on_blastnode,
 })
 
-minetest.register_craft({
-	output = 'mesecons_detector:node_detector_off',
-	recipe = {
-		{"default:steel_ingot", "group:mesecon_conductor_craftable", "default:steel_ingot"},
-		{"default:steel_ingot", "mesecons_luacontroller:luacontroller0000", "default:steel_ingot"},
-		{"default:steel_ingot", "default:steel_ingot", "default:steel_ingot"},
-	}
-})
+if minetest.get_modpath("mesecons_luacontroller") then
+	minetest.register_craft({
+		output = 'mesecons_detector:node_detector_off',
+		recipe = {
+			{"default:steel_ingot", "group:mesecon_conductor_craftable", "default:steel_ingot"},
+			{"default:steel_ingot", "mesecons_luacontroller:luacontroller0000", "default:steel_ingot"},
+			{"default:steel_ingot", "default:steel_ingot", "default:steel_ingot"},
+		}
+	})
+else
+	minetest.register_craft({
+		output = 'mesecons_detector:node_detector_off',
+		recipe = {
+			{"default:steel_ingot", "group:mesecon_conductor_craftable", "default:steel_ingot"},
+			{"default:steel_ingot", "mesecons_microcontroller:microcontroller0000", "default:steel_ingot"},
+			{"default:steel_ingot", "default:steel_ingot", "default:steel_ingot"},
+		}
+	})
+end
 
 minetest.register_abm({
 	nodenames = {"mesecons_detector:node_detector_off"},

--- a/mesecons_detector/init.lua
+++ b/mesecons_detector/init.lua
@@ -98,7 +98,7 @@ minetest.register_node("mesecons_detector:object_detector_on", {
 	digiline = object_detector_digiline,
 	on_blast = mesecon.on_blastnode,
 })
-  
+
 minetest.register_craft({
 	output = 'mesecons_detector:object_detector_off',
 	recipe = {

--- a/mesecons_detector/init.lua
+++ b/mesecons_detector/init.lua
@@ -98,26 +98,24 @@ minetest.register_node("mesecons_detector:object_detector_on", {
 	digiline = object_detector_digiline,
 	on_blast = mesecon.on_blastnode,
 })
+  
+minetest.register_craft({
+	output = 'mesecons_detector:object_detector_off',
+	recipe = {
+		{"default:steel_ingot", "default:steel_ingot", "default:steel_ingot"},
+		{"default:steel_ingot", "mesecons_luacontroller:luacontroller0000", "default:steel_ingot"},
+		{"default:steel_ingot", "group:mesecon_conductor_craftable", "default:steel_ingot"},
+	}
+})
 
-if minetest.get_modpath("mesecons_luacontroller") then    
-	minetest.register_craft({
-		output = 'mesecons_detector:object_detector_off',
-		recipe = {
-			{"default:steel_ingot", "default:steel_ingot", "default:steel_ingot"},
-			{"default:steel_ingot", "mesecons_luacontroller:luacontroller0000", "default:steel_ingot"},
-			{"default:steel_ingot", "group:mesecon_conductor_craftable", "default:steel_ingot"},
-		}
-	})
-else
-	minetest.register_craft({
-		output = 'mesecons_detector:object_detector_off',
-		recipe = {
-			{"default:steel_ingot", "default:steel_ingot", "default:steel_ingot"},
-			{"default:steel_ingot", "mesecons_microcontroller:microcontroller0000", "default:steel_ingot"},
-			{"default:steel_ingot", "group:mesecon_conductor_craftable", "default:steel_ingot"},
-		}
-	})
-end
+minetest.register_craft({
+	output = 'mesecons_detector:object_detector_off',
+	recipe = {
+		{"default:steel_ingot", "default:steel_ingot", "default:steel_ingot"},
+		{"default:steel_ingot", "mesecons_microcontroller:microcontroller0000", "default:steel_ingot"},
+		{"default:steel_ingot", "group:mesecon_conductor_craftable", "default:steel_ingot"},
+	}
+})
 
 minetest.register_abm({
 	nodenames = {"mesecons_detector:object_detector_off"},
@@ -272,25 +270,23 @@ minetest.register_node("mesecons_detector:node_detector_on", {
 	on_blast = mesecon.on_blastnode,
 })
 
-if minetest.get_modpath("mesecons_luacontroller") then
-	minetest.register_craft({
-		output = 'mesecons_detector:node_detector_off',
-		recipe = {
-			{"default:steel_ingot", "group:mesecon_conductor_craftable", "default:steel_ingot"},
-			{"default:steel_ingot", "mesecons_luacontroller:luacontroller0000", "default:steel_ingot"},
-			{"default:steel_ingot", "default:steel_ingot", "default:steel_ingot"},
-		}
-	})
-else
-	minetest.register_craft({
-		output = 'mesecons_detector:node_detector_off',
-		recipe = {
-			{"default:steel_ingot", "group:mesecon_conductor_craftable", "default:steel_ingot"},
-			{"default:steel_ingot", "mesecons_microcontroller:microcontroller0000", "default:steel_ingot"},
-			{"default:steel_ingot", "default:steel_ingot", "default:steel_ingot"},
-		}
-	})
-end
+minetest.register_craft({
+	output = 'mesecons_detector:node_detector_off',
+	recipe = {
+		{"default:steel_ingot", "group:mesecon_conductor_craftable", "default:steel_ingot"},
+		{"default:steel_ingot", "mesecons_luacontroller:luacontroller0000", "default:steel_ingot"},
+		{"default:steel_ingot", "default:steel_ingot", "default:steel_ingot"},
+	}
+})
+
+minetest.register_craft({
+	output = 'mesecons_detector:node_detector_off',
+	recipe = {
+		{"default:steel_ingot", "group:mesecon_conductor_craftable", "default:steel_ingot"},
+		{"default:steel_ingot", "mesecons_microcontroller:microcontroller0000", "default:steel_ingot"},
+		{"default:steel_ingot", "default:steel_ingot", "default:steel_ingot"},
+	}
+})
 
 minetest.register_abm({
 	nodenames = {"mesecons_detector:node_detector_off"},


### PR DESCRIPTION
As of now, users who disable mesecons_luacontroller do not have an option to craft node or object detectors. Add check.