### PR TITLE
check for falling after piston pusher removal

### DIFF
--- a/mesecons_pistons/init.lua
+++ b/mesecons_pistons/init.lua
@@ -72,6 +72,7 @@ local function piston_remove_pusher(pos, node)
 		max_hear_distance = 20,
 		gain = 0.3,
 	})
+	minetest.check_for_falling(pusherpos)
 end
 
 local piston_on = function(pos, node)


### PR DESCRIPTION
If a falling node lied on the pusher, it will fall.
According to @Wuzzy2 also fixes #389.