### PR TITLE
Improve settings

### DIFF
--- a/mesecons/settings.lua
+++ b/mesecons/settings.lua
@@ -18,14 +18,8 @@ minetest.settings = minetest.settings or {
 	set_bool = function(_, k, v)
 		return minetest.setting_setbool(k, v)
 	end,
-	get_names = function()
-		return {}
-	end,
-	write = function()
-		return minetest.setting_save()
-	end,
 }
--- do not use get_np_group, set_np_group, remove or to_table
+-- do not use get_np_group, set_np_group, remove, get_names, write or to_table
 
 
 function mesecon.setting(setting, default)
@@ -33,6 +27,7 @@ function mesecon.setting(setting, default)
 		local read = minetest.settings:get_bool("mesecon."..setting, default)
 		if read == nil then -- legacy
 			return default
+		end
 		return read
 	elseif type(default) == "string" then
 		return minetest.settings:get("mesecon."..setting) or default

--- a/mesecons/settings.lua
+++ b/mesecons/settings.lua
@@ -1,15 +1,45 @@
 -- SETTINGS
+
+-- legacy:
+minetest.settings = minetest.settings or {
+	get = function(_, k)
+		return minetest.setting_get(k)
+	end,
+	get_bool = function(_, k, default)
+		local s = minetest.setting_getbool(k)
+		if s == nil then
+			s = default
+		end
+		return s
+	end,
+	set = function(_, k, v)
+		return minetest.setting_set(k, v)
+	end,
+	set_bool = function(_, k, v)
+		return minetest.setting_setbool(k, v)
+	end,
+	get_names = function()
+		return {}
+	end,
+	write = function()
+		return minetest.setting_save()
+	end,
+}
+-- do not use get_np_group, set_np_group, remove or to_table
+
+
 function mesecon.setting(setting, default)
 	if type(default) == "boolean" then
-		local read = minetest.setting_getbool("mesecon."..setting)
+		local read = minetest.settings:get_bool("mesecon."..setting, default)
+		 -- legacy:
 		if read == nil then
 			return default
 		else
 			return read
 		end
 	elseif type(default) == "string" then
-		return minetest.setting_get("mesecon."..setting) or default
+		return minetest.settings:get("mesecon."..setting) or default
 	elseif type(default) == "number" then
-		return tonumber(minetest.setting_get("mesecon."..setting) or default)
+		return tonumber(minetest.settings:get("mesecon."..setting) or default)
 	end
 end

--- a/mesecons/settings.lua
+++ b/mesecons/settings.lua
@@ -8,7 +8,7 @@ minetest.settings = minetest.settings or {
 	get_bool = function(_, k, default)
 		local s = minetest.setting_getbool(k)
 		if s == nil then
-			s = default
+			return default
 		end
 		return s
 	end,
@@ -31,12 +31,9 @@ minetest.settings = minetest.settings or {
 function mesecon.setting(setting, default)
 	if type(default) == "boolean" then
 		local read = minetest.settings:get_bool("mesecon."..setting, default)
-		 -- legacy:
-		if read == nil then
+		if read == nil then -- legacy
 			return default
-		else
-			return read
-		end
+		return read
 	elseif type(default) == "string" then
 		return minetest.settings:get("mesecon."..setting) or default
 	elseif type(default) == "number" then

--- a/mesecons_blinkyplant/init.lua
+++ b/mesecons_blinkyplant/init.lua
@@ -1,11 +1,13 @@
 -- The BLINKY_PLANT
 
+local blinky_plant_interval = mesecon.setting("blinky_plant_interval", 3)
+
 local toggle_timer = function (pos)
 	local timer = minetest.get_node_timer(pos)
 	if timer:is_started() then
 		timer:stop()
 	else
-		timer:start(mesecon.setting("blinky_plant_interval", 3))
+		timer:start(blinky_plant_interval)
 	end
 end
 

--- a/mesecons_detector/init.lua
+++ b/mesecons_detector/init.lua
@@ -2,7 +2,10 @@ local GET_COMMAND = "GET"
 
 -- Object detector
 -- Detects players in a certain radius
--- The radius can be specified in mesecons/settings.lua
+-- The radius can be specified in settings
+
+local detector_radius = mesecon.setting("detector_radius", 6)
+local node_detector_distance_max = mesecon.setting("node_detector_distance_max", 10)
 
 local function object_detector_make_formspec(pos)
 	local meta = minetest.get_meta(pos)
@@ -25,7 +28,7 @@ end
 
 -- returns true if player was found, false if not
 local function object_detector_scan(pos)
-	local objs = minetest.get_objects_inside_radius(pos, mesecon.setting("detector_radius", 6))
+	local objs = minetest.get_objects_inside_radius(pos, detector_radius)
 
 	-- abort if no scan results were found
 	if next(objs) == nil then return false end
@@ -142,7 +145,7 @@ local function node_detector_make_formspec(pos)
 	if meta:get_string("distance") == ""  then meta:set_string("distance", "0") end
 	meta:set_string("formspec", "size[9,2.5]" ..
 		"field[0.3,  0;9,2;scanname;Name of node to scan for (empty for any):;${scanname}]"..
-		"field[0.3,1.5;2.5,2;distance;Distance (0-"..mesecon.setting("node_detector_distance_max", 10).."):;${distance}]"..
+		"field[0.3,1.5;2.5,2;distance;Distance (0-"..node_detector_distance_max.."):;${distance}]"..
 		"field[3,1.5;4,2;digiline_channel;Digiline Channel (optional):;${digiline_channel}]"..
 		"button_exit[7,0.75;2,3;;Save]")
 end
@@ -167,9 +170,8 @@ local function node_detector_scan(pos)
 	local meta = minetest.get_meta(pos)
 
 	local distance = meta:get_int("distance")
-	local distance_max = mesecon.setting("node_detector_distance_max", 10)
 	if distance < 0 then distance = 0 end
-	if distance > distance_max then distance = distance_max end
+	distance = math.min(distance, node_detector_distance_max)
 
 	local frontname = minetest.get_node(
 		vector.subtract(pos, vector.multiply(minetest.facedir_to_dir(node.param2), distance + 1))
@@ -187,9 +189,8 @@ local node_detector_digiline = {
 			local meta = minetest.get_meta(pos)
 
 			local distance = meta:get_int("distance")
-			local distance_max = mesecon.setting("node_detector_distance_max", 10)
 			if distance < 0 then distance = 0 end
-			if distance > distance_max then distance = distance_max end
+			distance = math.min(distance, node_detector_distance_max)
 
 			if channel ~= meta:get_string("digiline_channel") then return end
 

--- a/mesecons_pressureplates/init.lua
+++ b/mesecons_pressureplates/init.lua
@@ -1,3 +1,5 @@
+local pplate_interval = mesecon.setting("pplate_interval", 0.1)
+
 local pp_box_off = {
 	type = "fixed",
 	fixed = { -7/16, -8/16, -7/16, 7/16, -7/16, 7/16 },
@@ -54,7 +56,7 @@ function mesecon.register_pressure_plate(basename, description, textures_off, te
 		pressureplate_basename = basename,
 		on_timer = pp_on_timer,
 		on_construct = function(pos)
-			minetest.get_node_timer(pos):start(mesecon.setting("pplate_interval", 0.1))
+			minetest.get_node_timer(pos):start(pplate_interval)
 		end,
 	},{
 		mesecons = {receptor = { state = mesecon.state.off, rules = mesecon.rules.pplate }},

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,43 @@
+[mesecons]
+
+mesecon.resumetime (Resume time) int 4
+mesecon.overheat_max (Overheat max) int 20
+mesecon.cooldown_time (Cooldown time) float 2.0
+mesecon.cooldown_granularity (Cooldown granularity) float 0.5
+
+
+[mesecons_blinkyplant]
+
+mesecon.blinky_plant_interval (Plant interval) int 3
+
+
+[mesecons_detector]
+
+mesecon.detector_radius (Detector radius) int 6
+mesecon.node_detector_distance_max (Detector max distance) int 10
+
+
+[mesecons_luacontroller]
+
+mesecon.luacontroller_string_rep_max (Max) int 64000
+mesecon.luacontroller_digiline_maxlen (Digiline max length) int 50000
+mesecon.luacontroller_maxevents (Max events) int 10000
+mesecon.luacontroller_memsize (Memory size) int 100000
+
+
+[mesecons_movestones]
+
+mesecon.movestone_speed (Speed) int 3
+mesecon.movestone_max_push (Max push) int 50
+mesecon.movestone_max_pull (Max pull) int 50
+
+
+[mesecons_pistons]
+
+mesecon.piston_max_push (Max push) int 15
+mesecon.piston_max_pull (Max pull) int 15
+
+
+[mesecons_pressureplates]
+
+mesecon.pplate_interval (Interval) float 0.1

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,43 +1,51 @@
 [mesecons]
-
-mesecon.resumetime (Actionqueue resume time) int 4
+#    This is the time in seconds to wait after starting the server before
+#    processing the ActionQueue, don't set this too low.
+mesecon.resumetime (ActionQueue resume time) int 4
+#    This is used for fast circuits.
+#    Gates, fpgas, luacontrollers and the like will overheat if their heats get this high.
 mesecon.overheat_max (Overheat max) int 20
+#    This is this time in second it takes to cool a maximal heated device.
 mesecon.cooldown_time (Cooldown time) float 2.0
+#    This is the time in seconds between cooldown steps.
+#    Setting this too low can overload the CPU.
 mesecon.cooldown_granularity (Cooldown granularity) float 0.5
 
-
 [mesecons_blinkyplant]
-
+#    This is the interval in seconds in which a blinky plant flips its state once.
 mesecon.blinky_plant_interval (Blinky Plant interval) int 3
 
-
 [mesecons_detector]
-
+#    This is the radius in that object detectors search for objects.
+#    An euclidean metric is used.
 mesecon.detector_radius (Object Detector radius) int 6
+#    This is the maximal distance that can be set for node detectors.
 mesecon.node_detector_distance_max (Node Detector max distance) int 10
 
-
 [mesecons_luacontroller]
-
+#    The result of the function string.rep can maximally have this many characters.
 mesecon.luacontroller_string_rep_max (string.rep result length limit) int 64000
+#    This is the maximum number of characters of serialized digiline messages.
 mesecon.luacontroller_digiline_maxlen (Digiline message size limit) int 50000
+#    Make this higher if your luacontroller code tends to time out.
 mesecon.luacontroller_maxevents (Max debug hook events per event) int 10000
-mesecon.luacontroller_memsize (Memory size in number of characters of serialized mem) int 100000
-
+#    This is the maximum number of characters of serialized mem per luacontroller.
+mesecon.luacontroller_memsize (Memory size) int 100000
 
 [mesecons_movestones]
-
+#    This is the speed of movestones in nodes per second.
 mesecon.movestone_speed (Speed) int 3
+#    This is the maximum amount of nodes that can be pushed by a movestone.
 mesecon.movestone_max_push (Max push) int 50
+#    This is the maximum amount of nodes that can be pulled by a sticky movestone.
 mesecon.movestone_max_pull (Max pull) int 50
 
-
 [mesecons_pistons]
-
+#    This is the maximum amount of nodes that can be pushed by a piston.
 mesecon.piston_max_push (Max push) int 15
+#    This is the maximum amount of nodes that can be pulled by a sticky piston.
 mesecon.piston_max_pull (Max pull) int 15
 
-
 [mesecons_pressureplates]
-
+#    This is the interval in which pressureplates check for objects lying on them.
 mesecon.pplate_interval (Check Interval) float 0.1

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,6 +1,6 @@
 [mesecons]
 
-mesecon.resumetime (Resume time) int 4
+mesecon.resumetime (Actionqueue resume time) int 4
 mesecon.overheat_max (Overheat max) int 20
 mesecon.cooldown_time (Cooldown time) float 2.0
 mesecon.cooldown_granularity (Cooldown granularity) float 0.5
@@ -8,21 +8,21 @@ mesecon.cooldown_granularity (Cooldown granularity) float 0.5
 
 [mesecons_blinkyplant]
 
-mesecon.blinky_plant_interval (Plant interval) int 3
+mesecon.blinky_plant_interval (Blinky Plant interval) int 3
 
 
 [mesecons_detector]
 
-mesecon.detector_radius (Detector radius) int 6
-mesecon.node_detector_distance_max (Detector max distance) int 10
+mesecon.detector_radius (Object Detector radius) int 6
+mesecon.node_detector_distance_max (Node Detector max distance) int 10
 
 
 [mesecons_luacontroller]
 
-mesecon.luacontroller_string_rep_max (Max) int 64000
-mesecon.luacontroller_digiline_maxlen (Digiline max length) int 50000
-mesecon.luacontroller_maxevents (Max events) int 10000
-mesecon.luacontroller_memsize (Memory size) int 100000
+mesecon.luacontroller_string_rep_max (string.rep result length limit) int 64000
+mesecon.luacontroller_digiline_maxlen (Digiline message size limit) int 50000
+mesecon.luacontroller_maxevents (Max debug hook events per event) int 10000
+mesecon.luacontroller_memsize (Memory size in number of characters of serialized mem) int 100000
 
 
 [mesecons_movestones]
@@ -40,4 +40,4 @@ mesecon.piston_max_pull (Max pull) int 15
 
 [mesecons_pressureplates]
 
-mesecon.pplate_interval (Interval) float 0.1
+mesecon.pplate_interval (Check Interval) float 0.1


### PR DESCRIPTION
Replaces and so closes #344.
Replaces and so closes #350.
- `minetest.settings` is used instead of the deprecated `minetest.setting_*` functions.
- There won't be crashes for old minetest versions because a fake `minetest.settings` is created for them. Ergo this PR can be merged earlier than #344.
- Settings are only loaded once per file (at load time).
- A `settingtypes.txt` file is added based on the one from #350 but improved.

I didn't test this yet perfectly.