### PR TITLE
Add missing sound effects and fix wrong pressure plate sounds

### DIFF
--- a/mesecons_delayer/init.lua
+++ b/mesecons_delayer/init.lua
@@ -158,6 +158,7 @@ minetest.register_node("mesecons_delayer:delayer_on_"..tostring(i), {
 	end,
 	delayer_time = delaytime,
 	delayer_offstate = "mesecons_delayer:delayer_off_"..tostring(i),
+	sounds = default.node_sound_stone_defaults(),
 	mesecons = {
 		receptor =
 		{

--- a/mesecons_extrawires/corner.lua
+++ b/mesecons_extrawires/corner.lua
@@ -40,6 +40,7 @@ minetest.register_node("mesecons_extrawires:corner_on", {
 	node_box = corner_nodebox,
 	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
 	drop = "mesecons_extrawires:corner_off",
+	sounds = default.node_sound_defaults(),
 	mesecons = {conductor =
 	{
 		state = mesecon.state.on,
@@ -68,6 +69,7 @@ minetest.register_node("mesecons_extrawires:corner_off", {
 	selection_box = corner_selectionbox,
 	node_box = corner_nodebox,
 	groups = {dig_immediate = 3},
+	sounds = default.node_sound_defaults(),
 	mesecons = {conductor =
 	{
 		state = mesecon.state.off,

--- a/mesecons_extrawires/crossover.lua
+++ b/mesecons_extrawires/crossover.lua
@@ -34,6 +34,7 @@ minetest.register_node("mesecons_extrawires:crossover_off", {
 	stack_max = 99,
 	selection_box = {type="fixed", fixed={-16/32-0.0001, -18/32, -16/32-0.001, 16/32+0.001, -5/32, 16/32+0.001}},
 	groups = {dig_immediate=3, mesecon=3},
+	sounds = default.node_sound_defaults(),
 	mesecons = {
 		conductor = {
 			states = crossover_states,
@@ -60,6 +61,7 @@ minetest.register_node("mesecons_extrawires:crossover_01", {
 	stack_max = 99,
 	selection_box = {type="fixed", fixed={-16/32-0.0001, -18/32, -16/32-0.001, 16/32+0.001, -5/32, 16/32+0.001}},
 	groups = {dig_immediate=3, mesecon=3, not_in_creative_inventory=1},
+	sounds = default.node_sound_defaults(),
 	mesecons = {
 		conductor = {
 			states = crossover_states,
@@ -86,6 +88,7 @@ minetest.register_node("mesecons_extrawires:crossover_10", {
 	stack_max = 99,
 	selection_box = {type="fixed", fixed={-16/32-0.0001, -18/32, -16/32-0.001, 16/32+0.001, -5/32, 16/32+0.001}},
 	groups = {dig_immediate=3, mesecon=3, not_in_creative_inventory=1},
+	sounds = default.node_sound_defaults(),
 	mesecons = {
 		conductor = {
 			states = crossover_states,
@@ -112,6 +115,7 @@ minetest.register_node("mesecons_extrawires:crossover_on", {
 	stack_max = 99,
 	selection_box = {type="fixed", fixed={-16/32-0.0001, -18/32, -16/32-0.001, 16/32+0.001, -5/32, 16/32+0.001}},
 	groups = {dig_immediate=3, mesecon=3, not_in_creative_inventory=1},
+	sounds = default.node_sound_defaults(),
 	mesecons = {
 		conductor = {
 			states = crossover_states,

--- a/mesecons_extrawires/tjunction.lua
+++ b/mesecons_extrawires/tjunction.lua
@@ -41,6 +41,7 @@ minetest.register_node("mesecons_extrawires:tjunction_on", {
 	node_box = tjunction_nodebox,
 	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
 	drop = "mesecons_extrawires:tjunction_off",
+	sounds = default.node_sound_defaults(),
 	mesecons = {conductor =
 	{
 		state = mesecon.state.on,
@@ -69,6 +70,7 @@ minetest.register_node("mesecons_extrawires:tjunction_off", {
 	selection_box = tjunction_selectionbox,
 	node_box = tjunction_nodebox,
 	groups = {dig_immediate = 3},
+	sounds = default.node_sound_defaults(),
 	mesecons = {conductor =
 	{
 		state = mesecon.state.off,

--- a/mesecons_extrawires/vertical.lua
+++ b/mesecons_extrawires/vertical.lua
@@ -88,7 +88,8 @@ mesecon.register_node("mesecons_extrawires:vertical", {
 	is_vertical_conductor = true,
 	drop = "mesecons_extrawires:vertical_off",
 	after_place_node = vertical_update,
-	after_dig_node = vertical_update
+	after_dig_node = vertical_update,
+	sounds = default.node_sound_defaults(),
 },{
 	tiles = {"mesecons_wire_off.png"},
 	groups = {dig_immediate=3},
@@ -121,7 +122,8 @@ mesecon.register_node("mesecons_extrawires:vertical_top", {
 	is_vertical_conductor = true,
 	drop = "mesecons_extrawires:vertical_off",
 	after_place_node = vertical_update,
-	after_dig_node = vertical_update
+	after_dig_node = vertical_update,
+	sounds = default.node_sound_defaults(),
 },{
 	tiles = {"mesecons_wire_off.png"},
 	mesecons = {conductor = {
@@ -152,7 +154,8 @@ mesecon.register_node("mesecons_extrawires:vertical_bottom", {
 	is_vertical_conductor = true,
 	drop = "mesecons_extrawires:vertical_off",
 	after_place_node = vertical_update,
-	after_dig_node = vertical_update
+	after_dig_node = vertical_update,
+	sounds = default.node_sound_defaults(),
 },{
 	tiles = {"mesecons_wire_off.png"},
 	mesecons = {conductor = {

--- a/mesecons_hydroturbine/init.lua
+++ b/mesecons_hydroturbine/init.lua
@@ -22,7 +22,7 @@ minetest.register_node("mesecons_hydroturbine:hydro_turbine_off", {
 		type = "fixed",
 		fixed = { -0.5, -0.5, -0.5, 0.5, 1.5, 0.5 },
 	},
-	sounds = default.node_sound_stone_defaults(),
+	sounds = default.node_sound_metal_defaults(),
 	mesecons = {receptor = {
 		state = mesecon.state.off
 	}},
@@ -51,7 +51,7 @@ minetest.register_node("mesecons_hydroturbine:hydro_turbine_on", {
 		type = "fixed",
 		fixed = { -0.5, -0.5, -0.5, 0.5, 1.5, 0.5 },
 	},
-	sounds = default.node_sound_stone_defaults(),
+	sounds = default.node_sound_metal_defaults(),
 	mesecons = {receptor = {
 		state = mesecon.state.on
 	}},

--- a/mesecons_insulated/init.lua
+++ b/mesecons_insulated/init.lua
@@ -33,6 +33,7 @@ minetest.register_node("mesecons_insulated:insulated_on", {
 	},
 	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
 	drop = "mesecons_insulated:insulated_off",
+	sounds = default.node_sound_defaults(),
 	mesecons = {conductor = {
 		state = mesecon.state.on,
 		offstate = "mesecons_insulated:insulated_off",
@@ -66,6 +67,7 @@ minetest.register_node("mesecons_insulated:insulated_off", {
 		fixed = { -16/32-0.001, -17/32, -3/32, 16/32+0.001, -13/32, 3/32 }
 	},
 	groups = {dig_immediate = 3},
+	sounds = default.node_sound_defaults(),
 	mesecons = {conductor = {
 		state = mesecon.state.off,
 		onstate = "mesecons_insulated:insulated_on",

--- a/mesecons_pistons/init.lua
+++ b/mesecons_pistons/init.lua
@@ -326,6 +326,7 @@ minetest.register_node("mesecons_pistons:piston_pusher_normal", {
 	node_box = piston_pusher_box,
 	on_rotate = piston_rotate_pusher,
 	drop = "",
+	sounds = default.node_sound_wood_defaults(),
 })
 
 -- Sticky ones
@@ -403,6 +404,7 @@ minetest.register_node("mesecons_pistons:piston_pusher_sticky", {
 	node_box = piston_pusher_box,
 	on_rotate = piston_rotate_pusher,
 	drop = "",
+	sounds = default.node_sound_wood_defaults(),
 })
 
 

--- a/mesecons_pressureplates/init.lua
+++ b/mesecons_pressureplates/init.lua
@@ -42,8 +42,18 @@ end
 -- tiles_on:	textures of the pressure plate when active
 -- image:	inventory and wield image of the pressure plate
 -- recipe:	crafting recipe of the pressure plate
+-- groups:	groups
+-- sounds:	sound table
 
-function mesecon.register_pressure_plate(basename, description, textures_off, textures_on, image_w, image_i, recipe)
+function mesecon.register_pressure_plate(basename, description, textures_off, textures_on, image_w, image_i, recipe, groups, sounds)
+	local groups_off, groups_on
+	if not groups then
+		groups = {}
+	end
+	local groups_off = table.copy(groups)
+	local groups_on = table.copy(groups)
+	groups_on.not_in_creative_inventory = 1
+
 	mesecon.register_node(basename, {
 		drawtype = "nodebox",
 		inventory_image = image_i,
@@ -56,17 +66,18 @@ function mesecon.register_pressure_plate(basename, description, textures_off, te
 		on_construct = function(pos)
 			minetest.get_node_timer(pos):start(mesecon.setting("pplate_interval", 0.1))
 		end,
+		sounds = sounds,
 	},{
 		mesecons = {receptor = { state = mesecon.state.off, rules = mesecon.rules.pplate }},
 		node_box = pp_box_off,
 		selection_box = pp_box_off,
-		groups = {snappy = 2, oddly_breakable_by_hand = 3},
+		groups = groups_off,
 		tiles = textures_off
 	},{
 		mesecons = {receptor = { state = mesecon.state.on, rules = mesecon.rules.pplate }},
 		node_box = pp_box_on,
 		selection_box = pp_box_on,
-		groups = {snappy = 2, oddly_breakable_by_hand = 3, not_in_creative_inventory = 1},
+		groups = groups_on,
 		tiles = textures_on
 	})
 
@@ -83,7 +94,9 @@ mesecon.register_pressure_plate(
 	{"jeija_pressure_plate_wood_on.png","jeija_pressure_plate_wood_on.png","jeija_pressure_plate_wood_on_edges.png"},
 	"jeija_pressure_plate_wood_wield.png",
 	"jeija_pressure_plate_wood_inv.png",
-	{{"group:wood", "group:wood"}})
+	{{"group:wood", "group:wood"}},
+	{ choppy = 3, oddly_breakable_by_hand = 3 },
+	default.node_sound_wood_defaults())
 
 mesecon.register_pressure_plate(
 	"mesecons_pressureplates:pressure_plate_stone",
@@ -92,4 +105,6 @@ mesecon.register_pressure_plate(
 	{"jeija_pressure_plate_stone_on.png","jeija_pressure_plate_stone_on.png","jeija_pressure_plate_stone_on_edges.png"},
 	"jeija_pressure_plate_stone_wield.png",
 	"jeija_pressure_plate_stone_inv.png",
-	{{"default:cobble", "default:cobble"}})
+	{{"default:cobble", "default:cobble"}},
+	{ cracky = 3, oddly_breakable_by_hand = 3 },
+	default.node_sound_stone_defaults())

--- a/mesecons_receiver/init.lua
+++ b/mesecons_receiver/init.lua
@@ -56,6 +56,7 @@ mesecon.register_node("mesecons_receiver:receiver", {
 	},
 	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
 	drop = "mesecons:wire_00000000_off",
+	sounds = default.node_sound_defaults(),
 }, {
 	tiles = {
 		"receiver_top_off.png",
@@ -104,6 +105,7 @@ mesecon.register_node("mesecons_receiver:receiver_up", {
 	},
 	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
 	drop = "mesecons:wire_00000000_off",
+	sounds = default.node_sound_defaults(),
 }, {
 	tiles = {"mesecons_wire_off.png"},
 	mesecons = {conductor = {
@@ -148,6 +150,7 @@ mesecon.register_node("mesecons_receiver:receiver_down", {
 	},
 	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
 	drop = "mesecons:wire_00000000_off",
+	sounds = default.node_sound_defaults(),
 }, {
 	tiles = {"mesecons_wire_off.png"},
 	mesecons = {conductor = {

--- a/mesecons_torch/init.lua
+++ b/mesecons_torch/init.lua
@@ -60,6 +60,7 @@ minetest.register_node("mesecons_torch:mesecon_torch_off", {
 	selection_box = torch_selectionbox,
 	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
 	drop = "mesecons_torch:mesecon_torch_on",
+	sounds = default.node_sound_defaults(),
 	mesecons = {receptor = {
 		state = mesecon.state.off,
 		rules = torch_get_output_rules
@@ -81,6 +82,7 @@ minetest.register_node("mesecons_torch:mesecon_torch_on", {
 	groups = {dig_immediate=3},
 	light_source = default.LIGHT_MAX-5,
 	description="Mesecon Torch",
+	sounds = default.node_sound_defaults(),
 	mesecons = {receptor = {
 		state = mesecon.state.on,
 		rules = torch_get_output_rules

--- a/mesecons_wires/init.lua
+++ b/mesecons_wires/init.lua
@@ -215,6 +215,7 @@ local function register_wires()
 			walkable = false,
 			drop = "mesecons:wire_00000000_off",
 			mesecon_wire = true,
+			sounds = default.node_sound_defaults(),
 			on_rotate = false,
 		}, {tiles = tiles_off, mesecons = meseconspec_off, groups = groups_off},
 		{tiles = tiles_on, mesecons = meseconspec_on, groups = groups_on})


### PR DESCRIPTION
This adds the missing sound effects of all nodes which didn't make any sounds. Completion has been verified by `qa_block`.

The incorrect sounds of pressure plates have also been fixed. They now sound like wood and stone instead of leaves. Also, I replaced the `snappy` group with `choppy` and `cracky`.

Fixes #399.