### PR TITLE
Replace ABM functions with per-node timers

### DIFF
--- a/mesecons_hydroturbine/init.lua
+++ b/mesecons_hydroturbine/init.lua
@@ -3,6 +3,13 @@
 -- Active if flowing >water< above it
 -- (does not work with other liquids)
 
+local function is_flowing_water(pos)
+	local name = minetest.get_node(pos).name
+	local is_water = minetest.get_item_group(name, "water") > 0
+	local is_flowing = minetest.registered_items[name].liquidtype == "flowing"
+	return (is_water and is_flowing)
+end
+
 minetest.register_node("mesecons_hydroturbine:hydro_turbine_off", {
 	drawtype = "mesh",
 	mesh = "jeija_hydro_turbine_off.obj",
@@ -27,6 +34,18 @@ minetest.register_node("mesecons_hydroturbine:hydro_turbine_off", {
 		state = mesecon.state.off
 	}},
 	on_blast = mesecon.on_blastnode,
+	on_construct = function(pos)
+		local timer = minetest.get_node_timer(pos)
+		timer:start(1)
+	end,
+	on_timer = function(pos)
+		local waterpos={x=pos.x, y=pos.y+1, z=pos.z}
+		if is_flowing_water(waterpos) then
+			minetest.set_node(pos, {name="mesecons_hydroturbine:hydro_turbine_on"})
+			mesecon.receptor_on(pos)
+		end
+		return true
+	end,
 })
 
 minetest.register_node("mesecons_hydroturbine:hydro_turbine_on", {
@@ -56,39 +75,29 @@ minetest.register_node("mesecons_hydroturbine:hydro_turbine_on", {
 		state = mesecon.state.on
 	}},
 	on_blast = mesecon.on_blastnode,
-})
-
-
-local function is_flowing_water(pos)
-	local name = minetest.get_node(pos).name
-	local is_water = minetest.get_item_group(name, "water") > 0
-	local is_flowing = minetest.registered_items[name].liquidtype == "flowing"
-	return (is_water and is_flowing)
-end
-
-minetest.register_abm({
-nodenames = {"mesecons_hydroturbine:hydro_turbine_off"},
-	interval = 1,
-	chance = 1,
-	action = function(pos, node, active_object_count, active_object_count_wider)
-		local waterpos={x=pos.x, y=pos.y+1, z=pos.z}
-		if is_flowing_water(waterpos) then
-			minetest.set_node(pos, {name="mesecons_hydroturbine:hydro_turbine_on"})
-			mesecon.receptor_on(pos)
-		end
+	on_construct = function(pos)
+		local timer = minetest.get_node_timer(pos)
+		timer:start(1)
 	end,
-})
-
-minetest.register_abm({
-nodenames = {"mesecons_hydroturbine:hydro_turbine_on"},
-	interval = 1,
-	chance = 1,
-	action = function(pos, node, active_object_count, active_object_count_wider)
+	on_timer = function(pos)
 		local waterpos={x=pos.x, y=pos.y+1, z=pos.z}
 		if not is_flowing_water(waterpos) then
 			minetest.set_node(pos, {name="mesecons_hydroturbine:hydro_turbine_off"})
 			mesecon.receptor_off(pos)
 		end
+		return true
+	end,
+})
+
+-- LBM to start timers on existing, ABM-driven nodes
+minetest.register_lbm({
+	name = "mesecons_hydroturbine:timer_init",
+	nodenames = {"mesecons_hydroturbine:hydro_turbine_off",
+			"mesecons_hydroturbine:hydro_turbine_on"},
+	run_at_every_load = false,
+	action = function(pos)
+		local timer = minetest.get_node_timer(pos)
+		timer:start(1)
 	end,
 })
 

--- a/mesecons_torch/init.lua
+++ b/mesecons_torch/init.lua
@@ -60,12 +60,16 @@ local torch_update = function(pos)
 		end
 	end
 
-	if is_powered and node.name == "mesecons_torch:mesecon_torch_on" then
-		minetest.swap_node(pos, {name = "mesecons_torch:mesecon_torch_off", param2 = node.param2})
-		mesecon.receptor_off(pos, torch_get_output_rules(node))
-	elseif node.name == "mesecons_torch:mesecon_torch_off" then
-		minetest.swap_node(pos, {name = "mesecons_torch:mesecon_torch_on", param2 = node.param2})
-		mesecon.receptor_on(pos, torch_get_output_rules(node))
+	if is_powered then
+		if node.name == "mesecons_torch:mesecon_torch_on" then
+			minetest.swap_node(pos, {name = "mesecons_torch:mesecon_torch_off", param2 = node.param2})
+			mesecon.receptor_off(pos, torch_get_output_rules(node))
+		end
+	else
+		if node.name == "mesecons_torch:mesecon_torch_off" then
+			minetest.swap_node(pos, {name = "mesecons_torch:mesecon_torch_on", param2 = node.param2})
+			mesecon.receptor_on(pos, torch_get_output_rules(node))
+		end
 	end
 	
 

--- a/mesecons_torch/init.lua
+++ b/mesecons_torch/init.lua
@@ -50,6 +50,7 @@ local torch_selectionbox =
 }
 
 local torch_update = function(pos)
+	
 	local node = minetest.get_node(pos)
 	local is_powered = false
 	for _, rule in ipairs(torch_get_input_rules(node)) do
@@ -59,16 +60,15 @@ local torch_update = function(pos)
 		end
 	end
 
-	if is_powered then
-		if node.name == "mesecons_torch:mesecon_torch_on" then
-			minetest.swap_node(pos, {name = "mesecons_torch:mesecon_torch_off", param2 = node.param2})
-			mesecon.receptor_off(pos, torch_get_output_rules(node))
-		end
+	if is_powered and node.name == "mesecons_torch:mesecon_torch_on" then
+		minetest.swap_node(pos, {name = "mesecons_torch:mesecon_torch_off", param2 = node.param2})
+		mesecon.receptor_off(pos, torch_get_output_rules(node))
 	elseif node.name == "mesecons_torch:mesecon_torch_off" then
 		minetest.swap_node(pos, {name = "mesecons_torch:mesecon_torch_on", param2 = node.param2})
 		mesecon.receptor_on(pos, torch_get_output_rules(node))
 	end
-	return true
+	
+
 end
 
 minetest.register_node("mesecons_torch:mesecon_torch_off", {


### PR DESCRIPTION
Since mesecons are machines, and therefore much more rare than "natural" nodes, it makes sense to activate them using callback for node timer, as opposed to introducing wide-sweep ABM scans.
In total, there are 4 files with 9 registered ABMs: one for torch, two for the turbine and solar panel, and 4 for detectors. I replaced them with per-node timer events and an LBM to migrate existing nodes (activate their timers).