### PR TITLE
Actionqueue timing

### DIFF
--- a/mesecons/actionqueue.lua
+++ b/mesecons/actionqueue.lua
@@ -82,8 +82,20 @@ minetest.register_globalstep(function (dtime)
 
 	while(#actions_now > 0) do -- execute highest priorities first, until all are executed
 		local hp = get_highest_priority(actions_now)
-		mesecon.queue:execute(actions_now[hp])
+		local action = actions_now[hp]
+
+		local ts0 = minetest.get_us_time()
+		mesecon.queue:execute(action)
 		table.remove(actions_now, hp)
+		local ts1 = minetest.get_us_time()
+		local step_diff = ts1 - ts0
+		if step_diff > 5000 then
+			local pos_str = "<none>"
+			if action.pos then
+				pos_str = minetest.pos_to_string(action.pos)
+			end
+			minetest.log("warning", "[mesecons] step took " .. step_diff .. " us @ " .. pos_str)
+		end
 	end
 
 	local t1 = minetest.get_us_time()

--- a/mesecons/actionqueue.lua
+++ b/mesecons/actionqueue.lua
@@ -63,6 +63,7 @@ minetest.register_globalstep(function (dtime)
 	-- don't even try if server has not been running for XY seconds; resumetime = time to wait
 	-- after starting the server before processing the ActionQueue, don't set this too low
 	if (m_time < resumetime) then return end
+	local t0 = minetest.get_us_time()
 	local actions = mesecon.tablecopy(mesecon.queue.actions)
 	local actions_now={}
 
@@ -83,6 +84,12 @@ minetest.register_globalstep(function (dtime)
 		local hp = get_highest_priority(actions_now)
 		mesecon.queue:execute(actions_now[hp])
 		table.remove(actions_now, hp)
+	end
+
+	local t1 = minetest.get_us_time()
+	local diff = t1 - t0
+	if diff > 100000 then
+		minetest.log("warning", "[mesecons] globalstep took " .. diff .. " us")
 	end
 end)
 


### PR DESCRIPTION
Adds optional actionqueue timing, useful for server owners, disabled by default:

Settings:
```
# enable timing logging
mesecon.actionqueue_timing_log = true

# threshold for whole actionqueue step, in microseconds, default: 100'000 / 100 ms
mesecon.actionqueue_timing_step_threshold = 100000

# threshold for single action timing, in microseconds, default: 10'000 / 10 ms
mesecon.actionqueue_timing_action_threshold = 10000
```
