### PR TITLE
Luacontroller nodetimer

### DIFF
--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -271,8 +271,9 @@ local get_interrupt
 if mesecon.setting("luacontroller_lightweight_interrupts", false) then
 	-- use node timer
 	get_interrupt = function(pos, itbl, send_warning)
-		return (function(time)
-			if type(time) ~= "number" then return end
+		return (function(time, iid)
+			if type(time) ~= "number" then error("Delay must be a number") end
+			if iid ~= nil then send_warning("Interrupt IDs are disabled on this server") end
 			table.insert(itbl, function() minetest.get_node_timer(pos):start(time) end)
 		end)
 	end
@@ -284,7 +285,7 @@ else
 		local function interrupt(time, iid)
 			-- NOTE: This runs within string metatable sandbox, so don't *rely* on anything of the form (""):y
 			-- Hence the values get moved out. Should take less time than original, so totally compatible
-			if type(time) ~= "number" then return end
+			if type(time) ~= "number" then error("Delay must be a number") end
 			table.insert(itbl, function ()
 				-- Outside string metatable sandbox, can safely run this now
 				local luac_id = minetest.get_meta(pos):get_int("luac_id")
@@ -662,7 +663,7 @@ local function reset(pos)
 end
 
 local function node_timer(pos)
-	if (minetest.registered_nodes[minetest.get_node(pos).name].is_burnt) then
+	if minetest.registered_nodes[minetest.get_node(pos).name].is_burnt then
 		return false
 	end
 	run(pos, {type="interrupt"})

--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -283,12 +283,12 @@ local function get_interrupt(pos, itbl, send_warning)
 			local msg_ser = minetest.serialize(iid)
 			if #msg_ser <= mesecon.setting("luacontroller_interruptid_maxlen", 256) then
 				if mesecon.setting("luacontroller_nodetimer", false) then
-					-- use global action queue
-					mesecon.queue:add_action(pos, "lc_interrupt", {luac_id, iid}, time, iid, 1)
-				else
 					-- use node timer
 					minetest.get_meta(pos):set_string("iid", iid)
 					minetest.get_node_timer(pos):start(time)
+				else
+					-- use global action queue
+					mesecon.queue:add_action(pos, "lc_interrupt", {luac_id, iid}, time, iid, 1)
 				end
 			else
 				send_warning("An interrupt ID was too large!")

--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -421,16 +421,6 @@ local function get_digiline_send(pos, itbl, send_warning)
 	end
 end
 
-local function node_timer(pos)
-	local iid = minetest.get_meta(pos):get_string("iid")
-	if (minetest.registered_nodes[minetest.get_node(pos).name].is_burnt) then
-		return false
-	end
-	run(pos, {type="interrupt", iid = iid})
-	return false
-end
-
-
 local safe_globals = {
 	-- Don't add pcall/xpcall unless willing to deal with the consequences (unless very careful, incredibly likely to allow killing server indirectly)
 	"assert", "error", "ipairs", "next", "pairs", "select",
@@ -664,6 +654,15 @@ end
 
 local function reset(pos)
 	set_port_states(pos, {a=false, b=false, c=false, d=false})
+end
+
+local function node_timer(pos)
+	local iid = minetest.get_meta(pos):get_string("iid")
+	if (minetest.registered_nodes[minetest.get_node(pos).name].is_burnt) then
+		return false
+	end
+	run(pos, {type="interrupt", iid = iid})
+	return false
 end
 
 -----------------------

--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -282,9 +282,8 @@ local function get_interrupt(pos, itbl, send_warning)
 			iid = remove_functions(iid)
 			local msg_ser = minetest.serialize(iid)
 			if #msg_ser <= mesecon.setting("luacontroller_interruptid_maxlen", 256) then
-				if mesecon.setting("luacontroller_nodetimer", false) then
+				if mesecon.setting("luacontroller_lightweight_interrupts", false) then
 					-- use node timer
-					minetest.get_meta(pos):set_string("iid", iid)
 					minetest.get_node_timer(pos):start(time)
 				else
 					-- use global action queue
@@ -657,11 +656,10 @@ local function reset(pos)
 end
 
 local function node_timer(pos)
-	local iid = minetest.get_meta(pos):get_string("iid")
 	if (minetest.registered_nodes[minetest.get_node(pos).name].is_burnt) then
 		return false
 	end
-	run(pos, {type="interrupt", iid = iid})
+	run(pos, {type="interrupt"})
 	return false
 end
 

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -24,6 +24,10 @@ mesecon.luacontroller_digiline_maxlen (Digiline message size limit) int 50000 10
 mesecon.luacontroller_maxevents (Controller execution time limit) int 10000 1000 100000
 mesecon.luacontroller_memsize (Controller memory limit) int 100000 10000 1000000
 
+# Use node timer for interrupts (runs in active blocks only).
+# IID is ignored and at most one interrupt may be queued if this setting is enabled.
+mesecon.luacontroller_lightweight_interrupts (Lightweight interrupts) bool false
+
 
 [mesecons_movestones]
 


### PR DESCRIPTION
Adds optional nodetimer based luacontroller interrupts, useful for server owners, disabled by default:

Original idea by Joe7575 (https://forum.minetest.net/memberlist.php?mode=viewprofile&u=21063)

Settings:
```
# enable nodetimer based luacontroller interrupts (only active if a player is near them)
mesecon.luacontroller_nodetimer = true
```