### PR TITLE
Revert "Update init.lua" (getpos->get_pos)

### DIFF
--- a/mesecons_mvps/init.lua
+++ b/mesecons_mvps/init.lua
@@ -217,7 +217,7 @@ function mesecon.mvps_move_objects(pos, dir, nodestack, movefactor)
 	movefactor = movefactor or 1
 	dir = vector.multiply(dir, movefactor)
 	for id, obj in pairs(minetest.object_refs) do
-		local obj_pos = obj:getpos()
+		local obj_pos = obj:get_pos()
 		local cbox = obj:get_properties().collisionbox
 		local min_pos = vector.add(obj_pos, vector.new(cbox[1], cbox[2], cbox[3]))
 		local max_pos = vector.add(obj_pos, vector.new(cbox[4], cbox[5], cbox[6]))


### PR DESCRIPTION
Remove an annoying error message.

I think, it's time to think about compatibility to older minetest versions.
As minetest 5.0 is released, sooner or later everyone will use the new version to be able to connect to the majority of the servers. This means that there won't be anyone who would benefit from the compatibility with older versions.
I suggest:
1. For the next few months keep compatibility with 0.4.17.1, not to older versions.
2. Make a release or a tag or something the like.
3. Only keep compatibility with 5.0+.
4. **Profit** from easier to maintain and less warnings screaming code.