### PR TITLE
Use table.copy in mesecons.tablecopy

### DIFF
--- a/mesecons/util.lua
+++ b/mesecons/util.lua
@@ -186,19 +186,11 @@ function mesecon.invertRule(r)
 	return vector.multiply(r, -1)
 end
 
-function mesecon.tablecopy(table) -- deep table copy
-	if type(table) ~= "table" then return table end -- no need to copy
-	local newtable = {}
-
-	for idx, item in pairs(table) do
-		if type(item) == "table" then
-			newtable[idx] = mesecon.tablecopy(item)
-		else
-			newtable[idx] = item
-		end
+function mesecon.tablecopy(obj) -- deep copy
+	if type(obj) == "table" then
+		return table.copy(obj)
 	end
-
-	return newtable
+	return obj
 end
 
 function mesecon.cmpAny(t1, t2)


### PR DESCRIPTION
`mesecons.tablecopy` didn’t support recursive tables, while Minetest `table.copy` works well for them.

~~Fixes~~ #473 