### PR TITLE
set mvps_protection_mode default to the documented value

### DIFF
--- a/mesecons_mvps/init.lua
+++ b/mesecons_mvps/init.lua
@@ -163,7 +163,7 @@ local function add_pos(positions, pos)
 end
 
 local function are_protected(positions, player_name)
-	local mode = mesecon.setting("mvps_protection_mode", "normal")
+	local mode = mesecon.setting("mvps_protection_mode", "compat")
 	if mode == "ignore" then
 		return false
 	end


### PR DESCRIPTION
The default value of mvps_protection_mode differs in the settingtypes file and in the code. According to the PR for that feature, the default should be "compat", so I've changed the code so that it is "compat".