### PR TITLE
Do not print the mesecons OK message

### DIFF
--- a/mesecons/init.lua
+++ b/mesecons/init.lua
@@ -118,7 +118,7 @@ function mesecon.receptor_off(pos, rules)
 end
 
 
-print("[OK] Mesecons")
+minetest.log("info", "[OK] Mesecons")
 
 -- Deprecated stuff
 -- To be removed in future releases

--- a/mesecons/init.lua
+++ b/mesecons/init.lua
@@ -118,8 +118,6 @@ function mesecon.receptor_off(pos, rules)
 end
 
 
-minetest.log("info", "[OK] Mesecons")
-
 -- Deprecated stuff
 -- To be removed in future releases
 dofile(minetest.get_modpath("mesecons").."/legacy.lua");


### PR DESCRIPTION
I don't think it's important to print that the mod loading succeeded. Other mods also do not print a message when loading.