### PR TITLE
Add string.split function

### DIFF
--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -231,6 +231,16 @@ local function safe_string_find(...)
 	return string.find(...)
 end
 
+-- do not allow pattern matching in string.split (see string.find for details)
+local function safe_string_split(...)
+	if select(5, ...) then
+		debug.sethook() -- Clear hook
+		error("string.split: 'sep_is_pattern' (fifth parameter) may not be used in a Luacontroller")
+	end
+
+	return string.split(...)
+end
+
 local function remove_functions(x)
 	local tp = type(x)
 	if tp == "function" then
@@ -463,7 +473,7 @@ local function create_environment(pos, mem, event, itbl, send_warning)
 			reverse = string.reverse,
 			sub = string.sub,
 			find = safe_string_find,
-			split = string.split,
+			split = safe_string_split,
 		},
 		math = {
 			abs = math.abs,

--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -463,6 +463,7 @@ local function create_environment(pos, mem, event, itbl, send_warning)
 			reverse = string.reverse,
 			sub = string.sub,
 			find = safe_string_find,
+			split = string.split,
 		},
 		math = {
 			abs = math.abs,


### PR DESCRIPTION
Adds the default minetest string.split function.
I know it's just one helper function but it were also asked in #470 and should be pretty safe.
A player could anyway add it to his controller:
``` Lua
--  Copied from mt code: https://github.com/minetest/minetest/blob/0df646e0689b5324c7bdb13205c2a63e42ebe8e8/builtin/common/misc_helpers.lua#L169
function string.split(str, delim, include_empty, max_splits, sep_is_pattern)
	delim = delim or ","
	max_splits = max_splits or -2
	local items = {}
	local pos, len = 1, #str
	local plain = not sep_is_pattern
	max_splits = max_splits + 1
	repeat
		local np, npe = string.find(str, delim, pos, plain)
		np, npe = (np or (len+1)), (npe or (len+1))
		if (not np) or (max_splits == 1) then
			np = len + 1
			npe = np
		end
		local s = string.sub(str, pos, np - 1)
		if include_empty or (s ~= "") then
			max_splits = max_splits - 1
			items[#items + 1] = s
		end
		pos = npe + 1
	until (max_splits == 0) or (pos > (len + 1))
	return items
end
```
We could also set the max_splits to a specific value to be 100 % sure.