### PR TITLE
Make more nodes trigger special noteblock sounds

### DIFF
--- a/mesecons_noteblock/doc/noteblock/description.html
+++ b/mesecons_noteblock/doc/noteblock/description.html
@@ -1,12 +1,13 @@
-This effector makes a sound if powered and can be used for making music. Normally it makes piano sounds. The sound frequency can be changed by punching the block. There are some special sounds that depend on the block below:
+This effector makes a sound if powered and can be used for making music. Normally it makes piano sounds. The sound frequency can be changed by punching the block (only works for piano). There are some special sounds that depend on the block below:
 <table colspace="5">
 <tr><th>Block Below</th><th>Effect</th></tr>
-<tr><td>Glass</td><td>Hihat</td></tr>
-<tr><td>Stone</td><td>Kick</td></tr>
-<tr><td>Chest</td><td>Snare</td></tr>
-<tr><td>Tree</td><td>Crash</td></tr>
-<tr><td>Wood</td><td>Lite Crash</td></tr>
-<tr><td>Coal Block</td><td>Explosion Sound </td></tr>
-<tr><td>Lava Source</td><td>Fire Sound</td></tr>
-<tr><td>Steel Block</td><td>Raises the pitch by one octave</td></tr>
+<tr><td>Glass or Obsidian Glass</td><td>Hi-hat</td></tr>
+<tr><td>Any stone</td><td>Kick</td></tr>
+<tr><td>Chest or Locked Chest</td><td>Snare</td></tr>
+<tr><td>Any tree</td><td>Crash</td></tr>
+<tr><td>Any wooden planks</td><td>Lite Crash</td></tr>
+<tr><td>Coal Block</td><td>Explosion sound</td></tr>
+<tr><td>Lava Source</td><td>Fire sound</td></tr>
+<tr><td>Steel Block</td><td>Piano (high pitch, one octave higher than normal)</td></tr>
+<tr><td>Any other block</td><td>Piano (low pitch)</td></tr>
 </table>

--- a/mesecons_noteblock/init.lua
+++ b/mesecons_noteblock/init.lua
@@ -43,19 +43,33 @@ local soundnames = {
 }
 
 local node_sounds = {
-	["default:glass"] = "mesecons_noteblock_hihat",
-	["default:stone"] = "mesecons_noteblock_kick",
 	["default:lava_source"] = "fire_fire",
 	["default:chest"] = "mesecons_noteblock_snare",
-	["default:tree"] = "mesecons_noteblock_crash",
-	["default:wood"] = "mesecons_noteblock_litecrash",
+	["default:chest_locked"] = "mesecons_noteblock_snare",
 	["default:coalblock"] = "tnt_explode",
+	["default:glass"] = "mesecons_noteblock_hihat",
+	["default:obsidian_glass"] = "mesecons_noteblock_hihat",
+}
+
+local node_sounds_group = {
+	["stone"] = "mesecons_noteblock_kick",
+	["tree"] = "mesecons_noteblock_crash",
+	["wood"] = "mesecons_noteblock_litecrash",
 }
 
 mesecon.noteblock_play = function(pos, param2)
 	pos.y = pos.y-1
 	local nodeunder = minetest.get_node(pos).name
 	local soundname = node_sounds[nodeunder]
+	if not soundname then
+		for k,v in pairs(node_sounds_group) do
+			local g = minetest.get_item_group(nodeunder, k)
+			if g ~= 0 then
+				soundname = v
+				break
+			end
+		end
+	end
 	if not soundname then
 		soundname = soundnames[param2]
 		if not soundname then


### PR DESCRIPTION
This PR enables more nodes to trigger the special noteblock sounds:

* Hi-hat: Also accepts obsidian glass instead of only glass
* Snare: Also accepts locked chest instead of only chest
* Kick: Now accepts `group:stone` instead of only `default:stone`
* Crash: Now accepts `group:tree` instead of only `default:tree`
* Lite crash: Now accepts `group:wood` instead of only `default:wood`