### PR TITLE
mesecons_doors: Add MTG steel bar door and trapdoor

### DIFF
--- a/mesecons_doors/init.lua
+++ b/mesecons_doors/init.lua
@@ -73,6 +73,7 @@ meseconify_door("doors:door_wood")
 meseconify_door("doors:door_steel")
 meseconify_door("doors:door_glass")
 meseconify_door("doors:door_obsidian_glass")
+meseconify_door("xpanes:door_steel_bar")
 
 -- Trapdoor
 local function trapdoor_switch(pos, node)
@@ -110,6 +111,12 @@ if doors and doors.get then
 	minetest.override_item("doors:trapdoor_open", override)
 	minetest.override_item("doors:trapdoor_steel", override)
 	minetest.override_item("doors:trapdoor_steel_open", override)
+
+	if minetest.registered_items["xpanes:trapdoor_steel_bar"] then
+		minetest.override_item("xpanes:trapdoor_steel_bar", override)
+		minetest.override_item("xpanes:trapdoor_steel_bar_open", override)
+	end
+
 else
 	if minetest.registered_nodes["doors:trapdoor"] then
 		minetest.override_item("doors:trapdoor", {

--- a/mesecons_doors/mod.conf
+++ b/mesecons_doors/mod.conf
@@ -1,2 +1,3 @@
 name = mesecons_doors
 depends = mesecons, doors
+optional_depends = xpanes


### PR DESCRIPTION
Meseconify `xpanes:door_steel_bar` and `xpanes:trapdoor_steel_bar` from MTG (if `xpanes` is present)