### PR TITLE
add `.luacheckrc` / gh action and fix reported errors

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,0 +1,17 @@
+name: luacheck
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: apt
+      run: sudo apt-get install -y luarocks
+    - name: luacheck install
+      run: luarocks install --local luacheck
+    - name: luacheck run
+      run: $HOME/.luarocks/bin/luacheck ./

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,30 @@
+
+globals = {
+	"mesecon",
+	"minetest"
+}
+
+-- ignore unused vars
+unused = false
+
+read_globals = {
+	-- Stdlib
+	string = {fields = {"split"}},
+	table = {fields = {"copy", "getn"}},
+
+	-- Minetest
+	"vector", "ItemStack",
+	"dump", "VoxelArea",
+
+	-- system
+	"DIR_DELIM",
+
+	-- deps
+	"default", "screwdriver"
+}
+
+ignore = {
+	"631", -- line too long
+	"621", -- inconsistent indendation
+	"542", -- empty if branch
+}

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -16,9 +16,6 @@ read_globals = {
 	"vector", "ItemStack",
 	"dump", "VoxelArea",
 
-	-- system
-	"DIR_DELIM",
-
 	-- deps
 	"default", "screwdriver",
 	"digiline", "doors"

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -20,7 +20,8 @@ read_globals = {
 	"DIR_DELIM",
 
 	-- deps
-	"default", "screwdriver"
+	"default", "screwdriver",
+	"digiline", "doors"
 }
 
 ignore = {

--- a/mesecons/internal.lua
+++ b/mesecons/internal.lua
@@ -520,8 +520,8 @@ function mesecon.is_powered(pos, rule)
 	local sourcepos = {}
 
 	if not rule then
-		for _, rule in ipairs(mesecon.flattenrules(rules)) do
-			local rulenames = mesecon.rules_link_rule_all_inverted(pos, rule)
+		for _, rule_entry in ipairs(mesecon.flattenrules(rules)) do
+			local rulenames = mesecon.rules_link_rule_all_inverted(pos, rule_entry)
 			for _, rname in ipairs(rulenames) do
 				local np = vector.add(pos, rname)
 				local nn = mesecon.get_node_force(np)

--- a/mesecons/internal.lua
+++ b/mesecons/internal.lua
@@ -316,7 +316,7 @@ function mesecon.get_conductor_on(node_off, rulename)
 			return conductor.states[tonumber(binstate,2)+1]
 		end
 	end
-	return offstate
+	return nil
 end
 
 function mesecon.get_conductor_off(node_on, rulename)
@@ -332,7 +332,7 @@ function mesecon.get_conductor_off(node_on, rulename)
 			return conductor.states[tonumber(binstate,2)+1]
 		end
 	end
-	return onstate
+	return nil
 end
 
 function mesecon.conductor_get_rules(node)

--- a/mesecons/legacy.lua
+++ b/mesecons/legacy.lua
@@ -11,4 +11,4 @@ local old_forceloaded_blocks = mesecon.file2table("mesecon_forceloaded")
 for hash, _ in pairs(old_forceloaded_blocks) do
 	minetest.forceload_free_block(unhash_blockpos(hash))
 end
-os.remove(minetest.get_worldpath()..DIR_DELIM.."mesecon_forceloaded")
+os.remove(minetest.get_worldpath().."/mesecon_forceloaded")

--- a/mesecons/util.lua
+++ b/mesecons/util.lua
@@ -248,7 +248,7 @@ end
 -- File writing / reading utilities
 local wpath = minetest.get_worldpath()
 function mesecon.file2table(filename)
-	local f = io.open(wpath..DIR_DELIM..filename, "r")
+	local f = io.open(wpath.."/"..filename, "r")
 	if f == nil then return {} end
 	local t = f:read("*all")
 	f:close()
@@ -257,7 +257,7 @@ function mesecon.file2table(filename)
 end
 
 function mesecon.table2file(filename, table)
-	local f = io.open(wpath..DIR_DELIM..filename, "w")
+	local f = io.open(wpath.."/"..filename, "w")
 	f:write(minetest.serialize(table))
 	f:close()
 end

--- a/mesecons/util.lua
+++ b/mesecons/util.lua
@@ -332,13 +332,16 @@ local function vm_get_or_create_entry(pos)
 	return tbl
 end
 
+-- ignore content id
+local c_ignore = minetest.get_content_id("ignore")
+
 -- Gets the node at a given position during a VoxelManipulator-based
 -- transaction.
 function mesecon.vm_get_node(pos)
 	local tbl = vm_get_or_create_entry(pos)
 	local index = tbl.va:indexp(pos)
 	local node_value = tbl.data[index]
-	if node_value == core.CONTENT_IGNORE then
+	if node_value == c_ignore then
 		return nil
 	else
 		local node_param1 = tbl.param1[index]

--- a/mesecons_commandblock/init.lua
+++ b/mesecons_commandblock/init.lua
@@ -142,11 +142,11 @@ local function commandblock_action_on(pos, node)
 
 	local commands = resolve_commands(meta:get_string("commands"), pos)
 	for _, command in pairs(commands:split("\n")) do
-		local pos = command:find(" ")
+		local space_pos = command:find(" ")
 		local cmd, param = command, ""
-		if pos then
-			cmd = command:sub(1, pos - 1)
-			param = command:sub(pos + 1)
+		if space_pos then
+			cmd = command:sub(1, space_pos - 1)
+			param = command:sub(space_pos + 1)
 		end
 		local cmddef = minetest.chatcommands[cmd]
 		if not cmddef then

--- a/mesecons_extrawires/corner.lua
+++ b/mesecons_extrawires/corner.lua
@@ -30,7 +30,6 @@ minetest.register_node("mesecons_extrawires:corner_on", {
 	walkable = false,
 	sunlight_propagates = true,
 	selection_box = corner_selectionbox,
-	node_box = corner_nodebox,
 	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
 	drop = "mesecons_extrawires:corner_off",
 	sounds = default.node_sound_defaults(),
@@ -58,7 +57,6 @@ minetest.register_node("mesecons_extrawires:corner_off", {
 	walkable = false,
 	sunlight_propagates = true,
 	selection_box = corner_selectionbox,
-	node_box = corner_nodebox,
 	groups = {dig_immediate = 3},
 	sounds = default.node_sound_defaults(),
 	mesecons = {conductor =

--- a/mesecons_fpga/logic.lua
+++ b/mesecons_fpga/logic.lua
@@ -24,13 +24,13 @@ end
 
 -- (de)serialize
 lg.serialize = function(t)
-	local function _op(t)
-		if t == nil then
+	local function _op(_t)
+		if _t == nil then
 			return " "
-		elseif t.type == "io" then
-			return t.port
-		else -- t.type == "reg"
-			return tostring(t.n)
+		elseif _t.type == "io" then
+			return _t.port
+		else -- _t.type == "reg"
+			return tostring(_t.n)
 		end
 	end
 	-- Serialize actions (gates) from eg. "and" to "&"
@@ -97,11 +97,11 @@ end
 
 -- validation
 lg.validate_single = function(t, i)
-	local function is_reg_written_to(t, n, max)
-		for i = 1, max-1 do
-			if next(t[i]) ~= nil
-					and t[i].dst and t[i].dst.type == "reg"
-					and t[i].dst.n == n then
+	local function is_reg_written_to(_t, n, max)
+		for j = 1, max-1 do
+			if next(_t[j]) ~= nil
+					and _t[j].dst and _t[j].dst.type == "reg"
+					and _t[j].dst.n == n then
 				return true
 			end
 		end
@@ -187,11 +187,11 @@ lg.interpret = function(t, a, b, c, d)
 		end
 		return false -- unknown gate
 	end
-	local function _op(t, regs, io_in)
-		if t.type == "reg" then
-			return regs[t.n]
-		else -- t.type == "io"
-			return io_in[t.port]
+	local function _op(_t, regs, io_in)
+		if _t.type == "reg" then
+			return regs[_t.n]
+		else -- _t.type == "io"
+			return io_in[_t.port]
 		end
 	end
 

--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -574,15 +574,13 @@ end
 
 -- Returns success (boolean), errmsg (string)
 -- run (as opposed to run_inner) is responsible for setting up meta according to this output
-local function run_inner(pos, code, event)
-	local meta = minetest.get_meta(pos)
+local function run_inner(pos, meta, event)
 	-- Note: These return success, presumably to avoid changing LC ID.
 	if overheat(pos) then return true, "" end
 	if ignore_event(event, meta) then return true, "" end
 
 	-- Load code & mem from meta
 	local mem  = load_memory(meta)
-	code = meta:get_string("code")
 
 	-- 'Last warning' label.
 	local warning = ""
@@ -595,7 +593,7 @@ local function run_inner(pos, code, event)
 	local env = create_environment(pos, mem, event, itbl, send_warning)
 
 	-- Create the sandbox and execute code
-	local f, msg = create_sandbox(code, env)
+	local f, msg = create_sandbox(meta:get_string("code"), env)
 	if not f then return false, msg end
 	-- Start string true sandboxing
 	local onetruestring = getmetatable("")
@@ -651,7 +649,7 @@ end
 local function run(pos, event)
 	local meta = minetest.get_meta(pos)
 	local code = meta:get_string("code")
-	local ok, errmsg = run_inner(pos, code, event)
+	local ok, errmsg = run_inner(pos, meta, event)
 	if not ok then
 		reset_meta(pos, code, errmsg)
 	else

--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -231,8 +231,8 @@ local function safe_string_find(...)
 	return string.find(...)
 end
 
-local function remove_functions(x)
-	local tp = type(x)
+local function remove_functions(obj)
+	local tp = type(obj)
 	if tp == "function" then
 		return nil
 	end
@@ -261,9 +261,9 @@ local function remove_functions(x)
 		end
 	end
 
-	rfuncs(x)
+	rfuncs(obj)
 
-	return x
+	return obj
 end
 
 -- The setting affects API so is not intended to be changeable at runtime
@@ -582,7 +582,7 @@ local function run_inner(pos, code, event)
 
 	-- Load code & mem from meta
 	local mem  = load_memory(meta)
-	local code = meta:get_string("code")
+	code = meta:get_string("code")
 
 	-- 'Last warning' label.
 	local warning = ""
@@ -602,7 +602,8 @@ local function run_inner(pos, code, event)
 	-- If a string sandbox is already up yet inconsistent, something is very wrong
 	assert(onetruestring.__index == string)
 	onetruestring.__index = env.string
-	local success, msg = pcall(f)
+	local success
+	success, msg = pcall(f)
 	onetruestring.__index = string
 	-- End string true sandboxing
 	if not success then return false, msg end
@@ -901,4 +902,3 @@ minetest.register_craft({
 		{'group:mesecon_conductor_craftable', 'group:mesecon_conductor_craftable', ''},
 	}
 })
-

--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -60,7 +60,7 @@ local function update_real_port_states(pos, rule_name, new_state)
 	if rule_name.x == nil then
 		for _, rname in ipairs(rule_name) do
 			local port = pos_to_side[rname.x + (2 * rname.z) + 3]
-			L[port] = (newstate == "on") and 1 or 0
+			L[port] = (new_state == "on") and 1 or 0
 		end
 	else
 		local port = pos_to_side[rule_name.x + (2 * rule_name.z) + 3]

--- a/mesecons_microcontroller/init.lua
+++ b/mesecons_microcontroller/init.lua
@@ -188,9 +188,9 @@ yc.update = function(pos)
 
 	if (mesecon.do_overheat(pos)) then
 		minetest.remove_node(pos)
-		minetest.after(0.2, function (pos)
+		minetest.after(0.2, function()
 			mesecon.receptor_off(pos, mesecon.rules.flat)
-		end , pos) -- wait for pending parsings
+		end) -- wait for pending parsings
 		minetest.add_item(pos, "mesecons_microcontroller:microcontroller0000")
 	end
 
@@ -251,9 +251,9 @@ yc.parsecode = function(code, pos)
 			if not params then return nil end
 		end
 		if command == "on" then
-			L = yc.command_on (params, Lvirtual)
+			yc.command_on (params, Lvirtual)
 		elseif command == "off" then
-			L = yc.command_off(params, Lvirtual)
+			yc.command_off(params, Lvirtual)
 		elseif command == "print" then
 			local su = yc.command_print(params, eeprom, yc.merge_portstates(Lreal, Lvirtual))
 			if su ~= true then return nil end

--- a/mesecons_microcontroller/init.lua
+++ b/mesecons_microcontroller/init.lua
@@ -405,7 +405,7 @@ yc.command_print = function(params, eeprom, L)
 		if param:sub(1,1) == '"' and param:sub(#param, #param) == '"' then
 			s = s..param:sub(2, #param-1)
 		else
-			r = yc.command_parsecondition(param, L, eeprom)
+			local r = yc.command_parsecondition(param, L, eeprom)
 			if r == "1" or r == "0" then
 				s = s..r
 			else return nil end
@@ -543,12 +543,13 @@ yc.command_parsecondition = function(cond, L, eeprom)
 	cond = string.gsub(cond, "!0", "1")
 	cond = string.gsub(cond, "!1", "0")
 
-	local i = 2
-	local l = string.len(cond)
+	i = 2
+	l = string.len(cond)
 	while i<=l do
 		local s = cond:sub(i,i)
 		local b = tonumber(cond:sub(i-1, i-1))
 		local a = tonumber(cond:sub(i+1, i+1))
+		local buf
 		if cond:sub(i+1, i+1) == nil then break end
 		if s == "=" then
 			if a==nil then return nil end
@@ -562,8 +563,8 @@ yc.command_parsecondition = function(cond, L, eeprom)
 		i = i + 1
 	end
 
-	local i = 2
-	local l = string.len(cond)
+	i = 2
+	l = string.len(cond)
 	while i<=l do
 		local s = cond:sub(i,i)
 		local b = tonumber(cond:sub(i-1, i-1))

--- a/mesecons_microcontroller/init.lua
+++ b/mesecons_microcontroller/init.lua
@@ -469,8 +469,8 @@ yc.command_after_execute = function(params)
 		if yc.parsecode(params.code, params.pos) == nil then
 			meta:set_string("infotext", "Code in after() not valid!")
 		else
-			if code ~= nil then
-				meta:set_string("infotext", "Working Microcontroller\n"..code)
+			if params.code ~= nil then
+				meta:set_string("infotext", "Working Microcontroller\n"..params.code)
 			else
 				meta:set_string("infotext", "Working Microcontroller")
 			end

--- a/mesecons_pistons/init.lua
+++ b/mesecons_pistons/init.lua
@@ -500,4 +500,4 @@ minetest.register_craft({
 
 
 -- load legacy code
-dofile(minetest.get_modpath("mesecons_pistons")..DIR_DELIM.."legacy.lua")
+dofile(minetest.get_modpath("mesecons_pistons").."/legacy.lua")

--- a/mesecons_pistons/init.lua
+++ b/mesecons_pistons/init.lua
@@ -460,10 +460,10 @@ local piston_up_down_get_stopper = function (node, dir, stack, stackid)
 	return true
 end
 
-local function piston_get_stopper(node, dir, stack, stackid)
+local function piston_get_stopper(node, _, stack, stackid)
 	local pistonspec = get_pistonspec(node.name, "onname")
-	local inverted_dir = vector.multiply(minetest.facedir_to_dir(node.param2), -1)
-	local pusherpos = vector.add(stack[stackid].pos, inverted_dir)
+	local dir = vector.multiply(minetest.facedir_to_dir(node.param2), -1)
+	local pusherpos = vector.add(stack[stackid].pos, dir)
 	local pushernode = minetest.get_node(pusherpos)
 	if pistonspec.pusher == pushernode.name then
 		for _, s in ipairs(stack) do

--- a/mesecons_pistons/init.lua
+++ b/mesecons_pistons/init.lua
@@ -22,7 +22,7 @@ local function get_pistonspec_name(name, part)
 		return
 	end
 	for spec_name, spec in pairs(specs) do
-		for part, value in pairs(spec)  do
+		for _, value in pairs(spec)  do
 			if name == value then
 				return spec_name, part
 			end
@@ -462,8 +462,8 @@ end
 
 local function piston_get_stopper(node, dir, stack, stackid)
 	local pistonspec = get_pistonspec(node.name, "onname")
-	local dir = vector.multiply(minetest.facedir_to_dir(node.param2), -1)
-	local pusherpos = vector.add(stack[stackid].pos, dir)
+	local inverted_dir = vector.multiply(minetest.facedir_to_dir(node.param2), -1)
+	local pusherpos = vector.add(stack[stackid].pos, inverted_dir)
 	local pushernode = minetest.get_node(pusherpos)
 	if pistonspec.pusher == pushernode.name then
 		for _, s in ipairs(stack) do

--- a/mesecons_pressureplates/init.lua
+++ b/mesecons_pressureplates/init.lua
@@ -50,8 +50,8 @@ function mesecon.register_pressure_plate(basename, description, textures_off, te
 	if not groups then
 		groups = {}
 	end
-	local groups_off = table.copy(groups)
-	local groups_on = table.copy(groups)
+	groups_off = table.copy(groups)
+	groups_on = table.copy(groups)
 	groups_on.not_in_creative_inventory = 1
 
 	mesecon.register_node(basename, {

--- a/mesecons_random/init.lua
+++ b/mesecons_random/init.lua
@@ -59,7 +59,7 @@ minetest.register_node("mesecons_random:ghoststone_active", {
 	}},
 	on_construct = function(pos)
 		-- remove shadow
-		shadowpos = vector.add(pos, vector.new(0, 1, 0))
+		local shadowpos = vector.add(pos, vector.new(0, 1, 0))
 		if (minetest.get_node(shadowpos).name == "air") then
 			minetest.dig_node(shadowpos)
 		end


### PR DESCRIPTION
# Overview

This PR adds a `.luacheckrc` and the corresponding github action to check on every PR and Push.

# TODO

* [ ] ~~enable github actions on the current PR for testing~~
* [x] Fix remaining errors
* [x] Resolve more severe code-issues below

## silenced luacheck errors

The following error-types are silenced for this PR:
```lua
ignore = {
	"631", -- line too long
	"621", -- inconsistent indendation
	"542", -- empty if branch
}
```

# Unresolved code-issues

## microcontroller

`code` in this context is global and should be always nil:
https://github.com/minetest-mods/mesecons/blob/9fda51b650c83aea82616055ae8814a722353bf4/mesecons_microcontroller/init.lua#L472

## luacontroller

`newstate` is a global variable, `L[port]` should always be `0`
https://github.com/minetest-mods/mesecons/blob/9fda51b650c83aea82616055ae8814a722353bf4/mesecons_luacontroller/init.lua#L63

## extrawires

`corner_nodebox` is global and not defined within the mod:
https://github.com/minetest-mods/mesecons/blob/9fda51b650c83aea82616055ae8814a722353bf4/mesecons_extrawires/corner.lua#L33
@numberZero this was your addition in #524 is there a file or something missing?

## base "mesecons" mod

`offstate` and `onstate` aren't defined anywhere:
https://github.com/minetest-mods/mesecons/blob/9fda51b650c83aea82616055ae8814a722353bf4/mesecons/internal.lua#L319
https://github.com/minetest-mods/mesecons/blob/9fda51b650c83aea82616055ae8814a722353bf4/mesecons/internal.lua#L335