### PR TITLE
Add piston overheating

### DIFF
--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -52,6 +52,18 @@ mesecon.movestone_max_pull (Max pull) int 50 1 100
 mesecon.piston_max_push (Max push) int 15 1 100
 mesecon.piston_max_pull (Max pull) int 15 1 100
 
+# Unlike most devices, pistons don't break permanently
+# after overheating. They cooldown automatically (unless
+# disabled, see piston_cooldown_method) after given amount
+# of time, becoming working again.
+mesecon.piston_cooldown_time (Piston cooldown time, in seconds) float 5.0 1.0 60.0
+
+# Cooldown method can be choosen:
+# - timer: cooldown happens in active blocks only (but the timer itself persists even server restarts)
+# - actionqueue: cooldown happens when its time comes. Persists server restarts too.
+# - none: disable cooldown. Queued events are discarded.
+mesecon.piston_cooldown_method (Piston cooldown method) enum timer timer,actionqueue,none
+
 
 [mesecons_pressureplates]
 


### PR DESCRIPTION
Fix #499. Alternative to #526.
Pistons work at full speed but overheat if overloaded, just like most other items. Unlike those, a piston will cool down automatically, as requested by @Desour. The cooldown can be disabled if desired.
BTW should overheated pistons have different textures? Overheating isn’t immediately visible on many real-world devices (until you look inside) though on others it’s pretty obvious.