### PR TITLE
Replace mesecon.mergetable

### DIFF
--- a/mesecons/internal.lua
+++ b/mesecons/internal.lua
@@ -92,8 +92,8 @@ function mesecon.get_any_inputrules(node)
 end
 
 function mesecon.get_any_rules(node)
-	return mesecon.mergetable(mesecon.get_any_inputrules(node) or {},
-		mesecon.get_any_outputrules(node) or {})
+	return mesecon.merge_rule_sets(mesecon.get_any_inputrules(node),
+		mesecon.get_any_outputrules(node))
 end
 
 -- Receptors

--- a/mesecons/presets.lua
+++ b/mesecons/presets.lua
@@ -16,9 +16,9 @@ mesecon.rules.default = {
 	{x =  0, y = -1, z = -1},
 }
 
-mesecon.rules.floor = mesecon.mergetable(mesecon.rules.default, {{x = 0, y = -1, z = 0}})
+mesecon.rules.floor = mesecon.merge_rule_sets(mesecon.rules.default, {{x = 0, y = -1, z = 0}})
 
-mesecon.rules.pplate = mesecon.mergetable(mesecon.rules.floor, {{x = 0, y = -2, z = 0}})
+mesecon.rules.pplate = mesecon.merge_rule_sets(mesecon.rules.floor, {{x = 0, y = -2, z = 0}})
 
 mesecon.rules.buttonlike = {
 	{x = 1,  y =  0, z =  0},

--- a/mesecons/util.lua
+++ b/mesecons/util.lua
@@ -204,7 +204,7 @@ function mesecon.cmpAny(t1, t2)
 	return true
 end
 
--- does not overwrite values; number keys (ipairs) are appended, not overwritten
+-- Deprecated. Use `merge_replace` or `merge_rule_sets` as appropriate.
 function mesecon.mergetable(source, dest)
 	local rval = mesecon.tablecopy(dest)
 
@@ -216,6 +216,32 @@ function mesecon.mergetable(source, dest)
 	end
 
 	return rval
+end
+
+-- Merges several rule sets in one. Order may not be preserved. Nil arguments
+-- are ignored.
+-- The rule sets must be of the same kind (either all single-level or all two-level).
+-- The function may be changed to normalize the resulting set in some way.
+function mesecon.merge_rule_sets(...)
+	local rval = {}
+	for _, t in pairs({...}) do -- ignores nils automatically
+		table.insert_all(rval, mesecon.tablecopy(t))
+	end
+	return rval
+end
+
+-- Merges two tables, with entries from `replacements` taking precedence over
+-- those from `base`. Returns the new table.
+-- Numerical indices aren’t handled specially.
+-- Values are copied, keys are referenced.
+function mesecon.merge_replace(base, replacements)
+	local ret = mesecon.tablecopy(replacements) -- these are never overriden so have to be copied in any case
+	for k, v in pairs(base) do
+		if ret[k] == nil then -- it could be `false`
+			ret[k] = mesecon.tablecopy(v)
+		end
+	end
+	return ret
 end
 
 function mesecon.register_node(name, spec_common, spec_off, spec_on)

--- a/mesecons/util.lua
+++ b/mesecons/util.lua
@@ -206,6 +206,7 @@ end
 
 -- Deprecated. Use `merge_replace` or `merge_rule_sets` as appropriate.
 function mesecon.mergetable(source, dest)
+	minetest.log("warning", debug.traceback("Deprecated call to mesecon.mergetable"))
 	local rval = mesecon.tablecopy(dest)
 
 	for k, v in pairs(source) do

--- a/mesecons/util.lua
+++ b/mesecons/util.lua
@@ -204,7 +204,7 @@ function mesecon.cmpAny(t1, t2)
 	return true
 end
 
--- Deprecated. Use `merge_replace` or `merge_rule_sets` as appropriate.
+-- Deprecated. Use `merge_tables` or `merge_rule_sets` as appropriate.
 function mesecon.mergetable(source, dest)
 	minetest.log("warning", debug.traceback("Deprecated call to mesecon.mergetable"))
 	local rval = mesecon.tablecopy(dest)
@@ -233,9 +233,9 @@ end
 
 -- Merges two tables, with entries from `replacements` taking precedence over
 -- those from `base`. Returns the new table.
+-- Values are deep-copied from either table, keys are referenced.
 -- Numerical indices aren’t handled specially.
--- Values are copied, keys are referenced.
-function mesecon.merge_replace(base, replacements)
+function mesecon.merge_tables(base, replacements)
 	local ret = mesecon.tablecopy(replacements) -- these are never overriden so have to be copied in any case
 	for k, v in pairs(base) do
 		if ret[k] == nil then -- it could be `false`
@@ -252,8 +252,8 @@ function mesecon.register_node(name, spec_common, spec_off, spec_on)
 	spec_on.__mesecon_state = "on"
 	spec_off.__mesecon_state = "off"
 
-	spec_on = mesecon.merge_replace(spec_common, spec_on);
-	spec_off = mesecon.merge_replace(spec_common, spec_off);
+	spec_on = mesecon.merge_tables(spec_common, spec_on);
+	spec_off = mesecon.merge_tables(spec_common, spec_off);
 
 	minetest.register_node(name .. "_on", spec_on)
 	minetest.register_node(name .. "_off", spec_off)

--- a/mesecons/util.lua
+++ b/mesecons/util.lua
@@ -251,8 +251,8 @@ function mesecon.register_node(name, spec_common, spec_off, spec_on)
 	spec_on.__mesecon_state = "on"
 	spec_off.__mesecon_state = "off"
 
-	spec_on = mesecon.mergetable(spec_common, spec_on);
-	spec_off = mesecon.mergetable(spec_common, spec_off);
+	spec_on = mesecon.merge_replace(spec_common, spec_on);
+	spec_off = mesecon.merge_replace(spec_common, spec_off);
 
 	minetest.register_node(name .. "_on", spec_on)
 	minetest.register_node(name .. "_off", spec_off)

--- a/mesecons_extrawires/mesewire.lua
+++ b/mesecons_extrawires/mesewire.lua
@@ -18,7 +18,7 @@ minetest.override_item("default:mese", {
 
 -- Copy node definition of powered mese from normal mese
 -- and brighten texture tiles to indicate mese is powered
-local powered_def = mesecon.merge_replace(minetest.registered_nodes["default:mese"], {
+local powered_def = mesecon.merge_tables(minetest.registered_nodes["default:mese"], {
 	drop = "default:mese",
 	light_source = 5,
 	mesecons = {conductor = {

--- a/mesecons_extrawires/mesewire.lua
+++ b/mesecons_extrawires/mesewire.lua
@@ -18,7 +18,7 @@ minetest.override_item("default:mese", {
 
 -- Copy node definition of powered mese from normal mese
 -- and brighten texture tiles to indicate mese is powered
-local powered_def = mesecon.mergetable(minetest.registered_nodes["default:mese"], {
+local powered_def = mesecon.merge_replace(minetest.registered_nodes["default:mese"], {
 	drop = "default:mese",
 	light_source = 5,
 	mesecons = {conductor = {


### PR DESCRIPTION
Fix #483.
The two `mergetable` use cases were in fact unrelated, so now there are two functions. The original `mergetable` is now deprecated. ~So, are there any standard ways to track and report its uses?~