### PR TITLE
Add library support to Luacontrollers

### DIFF
--- a/mesecons/util.lua
+++ b/mesecons/util.lua
@@ -193,6 +193,25 @@ function mesecon.tablecopy(obj) -- deep copy
 	return obj
 end
 
+-- Performs a deep copy of a table, changing the environment of any functions.
+-- Adapted from the builtin table.copy() function.
+function mesecon.tablecopy_change_env(t, env, seen)
+	local n = {}
+	seen = seen or {}
+	seen[t] = n
+	for k, v in pairs(t) do
+		if type(v) == "function" then
+			local newfunc = v
+			setfenv(newfunc, env)
+			n[(type(k) == "table" and (seen[k] or mesecon.tablecopy_change_env(k, env, seen))) or k] = newfunc
+		else
+		n[(type(k) == "table" and (seen[k] or mesecon.tablecopy_change_env(k, env, seen))) or k] =
+			(type(v) == "table" and (seen[v] or mesecon.tablecopy_change_env(v, env, seen))) or v
+		end
+	end
+	return n
+end
+
 -- Returns whether two values are equal.
 -- In tables, keys are compared for identity but values are compared recursively.
 -- There is no protection from infinite recursion.

--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -459,6 +459,16 @@ local function get_digiline_send(pos, itbl, send_warning)
 	end
 end
 
+mesecon.luacontroller_libraries = {}
+
+local function get_require(env)
+	return function(name)
+		if mesecon.luacontroller_libraries[name] then
+			return mesecon.tablecopy_change_env(mesecon.luacontroller_libraries[name],env)
+		end
+	end
+end
+
 local safe_globals = {
 	-- Don't add pcall/xpcall unless willing to deal with the consequences (unless very careful, incredibly likely to allow killing server indirectly)
 	"assert", "error", "ipairs", "next", "pairs", "select",
@@ -546,6 +556,8 @@ local function create_environment(pos, mem, event, itbl, send_warning)
 	for _, name in pairs(safe_globals) do
 		env[name] = _G[name]
 	end
+	
+	env.require = get_require(env)
 
 	return env
 end


### PR DESCRIPTION
This allows mods to provide their own libraries that can be accessed from within a Luacontroller, for example to make working with advanced digilines peripherals somewhat easier.
Libraries can be added to the mesecon.luacontroller_libraries table, and then the code running in the Luacontroller can use require() to request one. require() will return nil if the library is not present.

As some examples of where this could be useful:
- One of my mods (digistuff) provides a "touchscreen" that can display various GUIs, but controlling it is rather difficult. I have written a library to do it (TSLib) but at the moment the only way to use the library is to copy/paste it into the beginning of the LuaC program. This change would allow digistuff to supply the library itself, and LuaC programs could simply require("TSLib") to obtain a copy.
- On servers that use lightweight interrupts, a mod could provide various helper functions to implement IIDs in another way, or possibly provide an alternative to the whole interrupt() mechanism altogether.
- A server owner may desire to make certain game-related functions (such as minetest.get_craft_result(), minetest.get_server_status(), or possibly even the entire "minetest" table in singleplayer) available within Luacontrollers. This would allow that to be done without editing the mesecons_luacontroller mod itself.