### PR TITLE
Add setting to have overheat cooldown in steps

### DIFF
--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,9 +1,37 @@
 [mesecons]
 
+# Number of seconds to wait after server start before starting to execute actions
+# from the actionqueue.
 mesecon.resumetime (Startup delay) int 4 1 10
-mesecon.overheat_max (Device heat limit) int 20 1 100
-mesecon.cooldown_time (Device cooldown time) float 2.0 0.1 10.0
-mesecon.cooldown_granularity (Cooldown step length) float 0.5 0.0 1.0
+
+# Heat at which a device overheats.
+# As a rule of thumb, a device gets 1 additional heat each time when it toggles.
+mesecon.overheat_max (Device heat limit) float 20.0 1.0
+
+# The method used to cooldown devices over time:
+# - seconds: The cooldown will happen per seconds.
+#   Use mesecon.cooldown_time and mesecon.cooldown_granularity for further configuration.
+# - steps: The cooldown will happen per server steps.
+#   Use mesecon.cooldown_time_steps and mesecon.cooldown_granularity_steps for further configuration.
+mesecon.cooldown_mode (Device cooldown mode) enum seconds seconds,steps
+
+# The time in seconds it takes for a device to fully cool down from max heat.
+# Only used if mesecon.cooldown_mode is seconds.
+mesecon.cooldown_time (Device cooldown time in seconds) float 2.0 0.0
+
+# Length in seconds of the interval in which devices are cooled down over time.
+# This does not affect the cooldown speed.
+# Only used if mesecon.cooldown_mode is seconds.
+mesecon.cooldown_granularity (Cooldown step length in seconds) float 0.5 0.0
+
+# The time in server steps it takes for a device to fully cool down from max heat.
+# Only used if mesecon.cooldown_mode is steps.
+mesecon.cooldown_time_steps (Device cooldown time in server steps) float 125.0 0.0
+
+# Length in server steps of the interval in which devices are cooled down over time.
+# This does not affect the cooldown speed.
+# Only used if mesecon.cooldown_mode is steps.
+mesecon.cooldown_granularity_steps (Cooldown step length in server steps) int 20 0
 
 
 [mesecons_blinkyplant]


### PR DESCRIPTION
## Problems to be solved:

Currently the cooldown is done in steps of seconds and the time it takes a device to fully cooldown is also in seconds.
Gates however have a delay in server steps (always exactly 2 steps). This makes it nearly impossible to build circuits that can never overheat, in any circumstances.
Also, servers have a much longer server step dtime, which results in inconsistencies and bad defaults (see also #561).

## Changes:

- A new setting `cooldown_mode` (enum: seconds(default), steps) says whether to use the old or the new method.
- Two new settings `cooldown_time_steps` (float, default=125.0) and `cooldown_granularity_steps` (int) can be used to configure the new mode, they work like their non-`_steps` counterparts.
- Rationale for not reusing the old settings: The values for `*_steps` are typically much higher. If you use an older mesecons version, the `cooldown_mode` setting is ignored and circuits will overheat. Also it's much more convenient to have separate settings if you want to play around with them. Furthermore, the new settings allow to define suitable defaults.
- Choice of values:
  125 steps is 2 seconds for a step time of 0.016 seconds. I was not able to measure a lower step time in singleplayer.
  This is a pretty strict value compared to the old settings. But it isn't actually _that_ strict, it allows one heat every 6.25 steps, which is enough for a shortcut NOT gate plus two diode gates for delay.
  The granularity of 20 steps if the same as 0.5 seconds with a dtime of 0.025 seconds.
  For servers the seconds-based cooldown would be ca. every 5 steps. So this value is more performance-friendly to servers.
  I currently don't know exactly if this value is good, but it's probably good enough.

## Other changes:

- Added documentation of settings in settingtypes.txt.
- Removed arbitrary limits in settingtypes.txt.
- Check lower bounds for settings in lua.
- Use float type for `overheat_max` in settingtypes.txt.