### PR TITLE
Fix use_texture_alpha warnings

### DIFF
--- a/mesecons_button/init.lua
+++ b/mesecons_button/init.lua
@@ -13,16 +13,19 @@ mesecon.button_turnoff = function (pos)
 	mesecon.receptor_off(pos, rules)
 end
 
+local use_texture_alpha = minetest.features.use_texture_alpha_string_modes and "opaque" or nil
+
 minetest.register_node("mesecons_button:button_off", {
 	drawtype = "nodebox",
 	tiles = {
-	"jeija_wall_button_sides.png",
-	"jeija_wall_button_sides.png",
-	"jeija_wall_button_sides.png",
-	"jeija_wall_button_sides.png",
-	"jeija_wall_button_sides.png",
-	"jeija_wall_button_off.png"
+		"jeija_wall_button_sides.png",
+		"jeija_wall_button_sides.png",
+		"jeija_wall_button_sides.png",
+		"jeija_wall_button_sides.png",
+		"jeija_wall_button_sides.png",
+		"jeija_wall_button_off.png"
 	},
+	use_texture_alpha = use_texture_alpha,
 	paramtype = "light",
 	paramtype2 = "facedir",
 	is_ground_content = false,
@@ -66,7 +69,8 @@ minetest.register_node("mesecons_button:button_on", {
 		"jeija_wall_button_sides.png",
 		"jeija_wall_button_sides.png",
 		"jeija_wall_button_on.png"
-		},
+	},
+	use_texture_alpha = use_texture_alpha,
 	paramtype = "light",
 	paramtype2 = "facedir",
 	is_ground_content = false,

--- a/mesecons_delayer/init.lua
+++ b/mesecons_delayer/init.lua
@@ -54,6 +54,7 @@ local boxes = {
 -- Delayer definition defaults
 local def = {
 	drawtype = "nodebox",
+	use_texture_alpha = minetest.features.use_texture_alpha_string_modes and "opaque" or nil,
 	walkable = true,
 	selection_box = {
 		type = "fixed",

--- a/mesecons_hydroturbine/init.lua
+++ b/mesecons_hydroturbine/init.lua
@@ -12,6 +12,7 @@ minetest.register_node("mesecons_hydroturbine:hydro_turbine_off", {
 		"jeija_hydro_turbine_turbine_top_bottom_off.png",
 		"jeija_hydro_turbine_turbine_misc_off.png"
 	},
+	use_texture_alpha = minetest.features.use_texture_alpha_string_modes and "opaque" or nil,
 	inventory_image = "jeija_hydro_turbine_inv.png",
 	is_ground_content = false,
 	wield_scale = {x=0.75, y=0.75, z=0.75},
@@ -42,6 +43,7 @@ minetest.register_node("mesecons_hydroturbine:hydro_turbine_on", {
 		{ name = "jeija_hydro_turbine_turbine_misc_on.png",
 		    animation = {type = "vertical_frames", aspect_w = 256, aspect_h = 32, length = 0.4} }
 	},
+	use_texture_alpha = minetest.features.use_texture_alpha_string_modes and "clip" or nil,
 	inventory_image = "jeija_hydro_turbine_inv.png",
 	drop = "mesecons_hydroturbine:hydro_turbine_off 1",
 	groups = {dig_immediate=2,not_in_creative_inventory=1},

--- a/mesecons_lamp/init.lua
+++ b/mesecons_lamp/init.lua
@@ -9,9 +9,12 @@ local mesecon_lamp_box = {
 	wall_side = {-0.375,-0.3125,-0.3125,-0.5,0.3125,0.3125},
 }
 
+local use_texture_alpha = minetest.features.use_texture_alpha_string_modes and "opaque" or nil
+
 minetest.register_node("mesecons_lamp:lamp_on", {
 	drawtype = "nodebox",
 	tiles = {"jeija_meselamp_on.png"},
+	use_texture_alpha = use_texture_alpha,
 	paramtype = "light",
 	paramtype2 = "wallmounted",
 	is_ground_content = false,
@@ -36,6 +39,7 @@ minetest.register_node("mesecons_lamp:lamp_on", {
 minetest.register_node("mesecons_lamp:lamp_off", {
 	drawtype = "nodebox",
 	tiles = {"jeija_meselamp_off.png"},
+	use_texture_alpha = use_texture_alpha,
 	inventory_image = "jeija_meselamp.png",
 	wield_image = "jeija_meselamp.png",
 	paramtype = "light",


### PR DESCRIPTION
Use everywhere `"opaque"`, but `"clip"` for `hydro_turbine_on` (tested, of course).