### PR TITLE
Fix conductor turnon link direction within on_placenode

### DIFF
--- a/mesecons/services.lua
+++ b/mesecons/services.lua
@@ -16,7 +16,7 @@ mesecon.on_placenode = function(pos, node)
 			-- also call receptor_on if itself is powered already, so that neighboring
 			-- conductors will be activated (when pushing an on-conductor with a piston)
 			for _, s in ipairs(sources) do
-				local rule = vector.subtract(pos, s)
+				local rule = vector.subtract(s, pos)
 				mesecon.turnon(pos, rule)
 			end
 			--mesecon.receptor_on (pos, mesecon.conductor_get_rules(node))


### PR DESCRIPTION
When testing this, I put this line at the beginning of `mesecon.turnon` to track calls to it:

```lua
minetest.chat_send_all(minetest.pos_to_string(pos) .. " " .. minetest.pos_to_string(link))
```

Then I placed a switch, turned it on, placed a regular wire adjacent to it, and turned the switch off and on again. With this PR, both calls to `turnon` output the same debugging information. Without it, the values of `link` are opposite to each other.

In other words, this PR makes the behavior when placing a conductor consistent with the behavior when turning on a receptor, with respect to the turned-on conductor.

I don't think the bug occurs with any built-in conductors, but it affects a mod I'm working on.