### PR TITLE
Handle getting out-of-bounds bits in get_bit

### DIFF
--- a/mesecons/util.lua
+++ b/mesecons/util.lua
@@ -163,12 +163,9 @@ function mesecon.getbinstate(nodename, states)
 end
 
 function mesecon.get_bit(binary,bit)
+	bit = bit or 1
 	local len = binary:len()
-	if bit then
-		if bit > len then return false end
-	else
-		bit = 1
-	end
+	if bit > len then return false end
 	local c = len-(bit-1)
 	return binary:sub(c,c) == "1"
 end

--- a/mesecons/util.lua
+++ b/mesecons/util.lua
@@ -163,8 +163,13 @@ function mesecon.getbinstate(nodename, states)
 end
 
 function mesecon.get_bit(binary,bit)
-	bit = bit or 1
-	local c = binary:len()-(bit-1)
+	local len = binary:len()
+	if bit then
+		if bit > len then return false end
+	else
+		bit = 1
+	end
+	local c = len-(bit-1)
 	return binary:sub(c,c) == "1"
 end
 


### PR DESCRIPTION
The binary state is not padded with zeroes, so they must be inferred.

## Testing

To test this, I added some custom node definitions to the end of `mesecons/init.lua`:

```lua                                 
local test_states = {"mesecons:t_off", "mesecons:t_001", "mesecons:t_010", "mesecons:t_011", "mesecons:t_100", "mesecons:t_101", "mesecons:t_110", "mesecons:t_on"}
for _, state in ipairs(test_states) do                                          
        minetest.register_node(state, {                                         
                description = "Test node",                                      
                mesecons = {conductor = {                                       
                        states = test_states,                                   
                        rules = {                                               
                                {                                               
                                        {x = -1, y = 0, z = 0},                 
                                        {x = 0, y = 0, z = -1},                 
                                },                                              
                                {                                               
                                        {x = 1, y = 0, z = 0},                  
                                        {x = 0, y = 0, z = 1},                  
                                },                                              
                                {                                               
                                        {x = 1, y = 1, z = 0},                  
                                        {x = -1, y = 1, z = 0},                 
                                        {x = 0, y = 1, z = 1},                  
                                        {x = 0, y = 1, z = -1},                 
                                },                                              
                        },                                                      
                }},                                                             
        })                                                                      
end
```

Then I constructed this:
![fix](https://user-images.githubusercontent.com/28828704/127508484-b94f68e8-face-4713-8847-d017816d1b51.png)
Notice that I'm facing in the +Z direction. The structures in the background don't matter.

When the switch in the center of the screen is on, you should be able to turn on the switch on the right and cause the wire on the left to turn on as well. This correctly occurs if you have applied the change from this PR. Without the change, the wire on the left is not turned on when the switch on the right is turned on.
