### PR TITLE
Optimize light updates when turning conductors on and off

### DIFF
--- a/mesecons/internal.lua
+++ b/mesecons/internal.lua
@@ -383,35 +383,33 @@ local function find_light_update_conductors()
 	local checked = {}
 	for name, def in pairs(minetest.registered_nodes) do
 		local conductor = mesecon.get_conductor(name)
-		if conductor then
-			if not checked[name] then
-				-- Find the other states of the conductor besides the current one.
-				local other_states
-				if conductor.onstate then
-					other_states = {conductor.onstate}
-				elseif conductor.offstate then
-					other_states = {conductor.offstate}
-				else
-					other_states = conductor.states
-				end
+		if conductor and not checked[name] then
+			-- Find the other states of the conductor besides the current one.
+			local other_states
+			if conductor.onstate then
+				other_states = {conductor.onstate}
+			elseif conductor.offstate then
+				other_states = {conductor.offstate}
+			else
+				other_states = conductor.states
+			end
 
-				-- Check the conductor. Other states are marked as checked.
-				for _, other_state in ipairs(other_states) do
-					local other_def = minetest.registered_nodes[other_state]
-					if (def.paramtype == "light") ~= (other_def.paramtype == "light")
-					or def.sunlight_propagates ~= other_def.sunlight_propagates
-					or def.light_source ~= other_def.light_source then
-						-- The light characteristics change depending on the state.
-						-- The states are added to the set.
-						light_update_conductors[name] = true
-						for _, other_state in ipairs(other_states) do
-							light_update_conductors[other_state] = true
-							checked[other_state] = true
-						end
-						break
+			-- Check the conductor. Other states are marked as checked.
+			for _, other_state in ipairs(other_states) do
+				local other_def = minetest.registered_nodes[other_state]
+				if (def.paramtype == "light") ~= (other_def.paramtype == "light")
+				or def.sunlight_propagates ~= other_def.sunlight_propagates
+				or def.light_source ~= other_def.light_source then
+					-- The light characteristics change depending on the state.
+					-- The states are added to the set.
+					light_update_conductors[name] = true
+					for _, other_state in ipairs(other_states) do
+						light_update_conductors[other_state] = true
+						checked[other_state] = true
 					end
-					checked[other_state] = true
+					break
 				end
+				checked[other_state] = true
 			end
 		end
 	end


### PR DESCRIPTION
## Overview

Most calls to `VoxelManip:write_to_map` made from `turnon` and `turnoff` do not need to include a light update, since most conductors do not change their lighting characteristics depending on their state. There are exceptions, including mese blocks and ghoststone blocks. Such exceptions are automatically handled in this PR. Most unnecessary light updates have been removed.

## Benchmarks

My changes create a measurable performance improvement. To measure them, I made this change to `mesecons/actionqueue.lua`:

```patch
diff --git a/mesecons/actionqueue.lua b/mesecons/actionqueue.lua
index 5508095..1ccddd5 100644
--- a/mesecons/actionqueue.lua
+++ b/mesecons/actionqueue.lua
@@ -70,6 +70,8 @@ end
 -- However, even that does not work in some cases, that's why we delay the time the globalsteps
 -- start to be execute by 4 seconds
 
+local sum = 0
+
 local function globalstep_func(dtime)
 	local actions = queue.actions
 	-- split into two categories:
@@ -106,10 +108,23 @@ local function globalstep_func(dtime)
 		end
 	end)
 
+	local has_actions = actions_now[1] ~= nil
+
+	local before
+	if has_actions then before = minetest.get_us_time() end
+
 	-- execute highest priorities first, until all are executed
 	for _, ac in ipairs(actions_now) do
 		queue:execute(ac)
 	end
+
+	local after
+	if has_actions then after = minetest.get_us_time() end
+
+	if has_actions then
+		sum = sum + (after - before)
+		minetest.chat_send_all(sum / 1000000)
+	end
 end
 
 -- delay the time the globalsteps start to be execute by 4 seconds
```

This prints the total action queue runtime after any action executes. You have to restart the server to reset the sum.

I ran these with and without the PR applied. Your benchmark results will probably differ from mine.

### Long line of diodes

WorldEdit schematic: [example-diodes.we.gz](https://github.com/minetest-mods/mesecons/files/7550372/example-diodes.we.gz)

To test this, turn the switch off then on again.

Runtime without PR: 0.53s
Runtime with PR: 0.29s

### Block of wires

WorldEdit schematic: [example-wireblock.we.gz](https://github.com/minetest-mods/mesecons/files/7550394/example-wireblock.we.gz)

To test this, turn the switch on and off again six times.

Runtime without PR: 5.717s
Runtime with PR: 5.70s

### 256 byte memory bank

WorldEdit schematic: [example-memory.we.gz](https://github.com/minetest-mods/mesecons/files/7550403/example-memory.we.gz)

Unlike the other benchmarks, this one is of a device with an actual purpose. The controls are at the northwest corner of the device. Before testing, turn on the leftmost switch and the switch at the bottom of the rightmost stack of switches.

To test this, turn the switch at the top of the rightmost stack on and off again six times. For consistency, make sure the circuitry settles down before each flip of the switch.

Runtime without PR: 5.21s
Runtime with PR: 3.64s

## Tests

These test functionality rather than performance.

### Mese block

WorldEdit schematic: [example-meseblock.we.gz](https://github.com/minetest-mods/mesecons/files/7550506/example-meseblock.we.gz)

The light emitted by the mese block changes depending on its conduction state. This test confirms that the light update occurs.

To run this test, enter the dark chamber and flip the switch.

### Ghoststone

WorldEdit schematic: [example-ghoststone.we.gz](https://github.com/minetest-mods/mesecons/files/7550509/example-ghoststone.we.gz)

Whether or not ghoststone lets light through depends on its conduction state. This test confirms that the light update occurs.

To run this test, enter the dark chamber and flip the switch.
