### PR TITLE
Fix torch rules

### DIFF
--- a/mesecons_torch/init.lua
+++ b/mesecons_torch/init.lua
@@ -27,9 +27,13 @@ local torch_get_output_rules = function(node)
 	return rotate_torch_rules(rules, node.param2)
 end
 
+local torch_input_rules_unrotated_horizontal = {vector.new(-2, 0, 0), vector.new(-1, 1, 0)}
+local torch_input_rules_unrotated_vertical   = {vector.new(-2, 0, 0)}
+
 local torch_get_input_rules = function(node)
-	local rules = 	{{x = -2, y = 0, z = 0},
-				 {x = -1, y = 1, z = 0}}
+	local rules = (node.param2 == 0 or node.param2 == 1)
+		and torch_input_rules_unrotated_vertical
+		or  torch_input_rules_unrotated_horizontal
 
 	return rotate_torch_rules(rules, node.param2)
 end


### PR DESCRIPTION
Fixes #580.

The extra rule is probably there to allow using conductors on top of the node that the torch is placed to:
![screenshot_20220119_002941](https://user-images.githubusercontent.com/7613443/150036018-70399a54-cf2e-4255-8ed3-885e322f884d.png)

But this rule should not be used for vertical torches.

Test by placing torches.