### PR TITLE
Fix conductor lighting when aliases are used

### DIFF
--- a/mesecons/internal.lua
+++ b/mesecons/internal.lua
@@ -372,7 +372,6 @@ end
 local light_update_conductors
 
 -- Calculate the contents of the above set if they have not been calculated.
--- This must be called before get_update_light_conductor.
 local function find_light_update_conductors()
 	-- The expensive calculation is only done the first time.
 	if light_update_conductors then return end
@@ -415,12 +414,6 @@ local function find_light_update_conductors()
 	end
 end
 
--- This is the callback for swap_node_force in turnon and turnoff. It determines
--- whether a conductor node necessitates a lighting update.
-local function get_update_light_conductor(pos, name)
-	return light_update_conductors[name] ~= nil
-end
-
 -- Turn off an equipotential section starting at `pos`, which outputs in the direction of `link`.
 -- Breadth-first search. Map is abstracted away in a voxelmanip.
 -- Follow all all conductor paths replacing conductors that were already
@@ -453,7 +446,7 @@ function mesecon.turnon(pos, link)
 					end
 				end
 
-				mesecon.swap_node_force(f.pos, mesecon.get_conductor_on(node, f.link), get_update_light_conductor)
+				mesecon.swap_node_force(f.pos, mesecon.get_conductor_on(node, f.link), light_update_conductors[node.name] ~= nil)
 			end
 
 			-- Only conductors with flat rules can be reliably skipped later
@@ -527,7 +520,7 @@ function mesecon.turnoff(pos, link)
 					end
 				end
 
-				mesecon.swap_node_force(f.pos, mesecon.get_conductor_off(node, f.link), get_update_light_conductor)
+				mesecon.swap_node_force(f.pos, mesecon.get_conductor_off(node, f.link), light_update_conductors[node.name] ~= nil)
 			end
 
 			-- Only conductors with flat rules can be reliably skipped later

--- a/mesecons/util.lua
+++ b/mesecons/util.lua
@@ -389,10 +389,10 @@ end
 --
 -- Existing param1, param2, and metadata are left alone.
 --
--- See mesecon.swap_node_force for documentation about get_update_light.
-function mesecon.vm_swap_node(pos, name, get_update_light)
+-- The swap will necessitate a light update unless update_light equals false.
+function mesecon.vm_swap_node(pos, name, update_light)
 	local tbl = vm_get_or_create_entry(pos)
-	tbl.update_light = tbl.update_light or (get_update_light == nil or get_update_light(pos, name))
+	tbl.update_light = update_light ~= false or tbl.update_light
 	local index = tbl.va:indexp(pos)
 	tbl.data[index] = minetest.get_content_id(name)
 	tbl.dirty = true
@@ -426,15 +426,15 @@ end
 -- Outside a VM transaction, if the mapblock is not loaded, it is pulled into
 -- the server’s main map data cache and then accessed from there.
 --
--- Inside a VM transaction, the transaction’s VM cache is used. If a third
--- argument is supplied, it may be called. If it returns false, the swap does
--- not necessitate a lighting update.
+-- Inside a VM transaction, the transaction’s VM cache is used.
 --
 -- This function can only be used to change the node’s name, not its parameters
 -- or metadata.
-function mesecon.swap_node_force(pos, name, get_update_light)
+--
+-- The swap will necessitate a light update unless update_light equals false.
+function mesecon.swap_node_force(pos, name, update_light)
 	if vm_cache then
-		return mesecon.vm_swap_node(pos, name, get_update_light)
+		return mesecon.vm_swap_node(pos, name, update_light)
 	else
 		-- This serves to both ensure the mapblock is loaded and also hand us
 		-- the old node table so we can preserve param2.


### PR DESCRIPTION
This fixes a theoretical issue with my last #578. This issue has to do with aliases. If one of the states listed in the conductor configuration is actually an alias, light updates may not work correctly. This is because the code does not get that the alias refers to the same node definition as the real node name. To amend this, the code now decides whether to update lighting based on the names of nodes that actually exist on the map, not states being changed to. These node names can never be aliases.

This PR simplifies the API of `swap_node_force`. Instead of providing a function, you provide a boolean directly. This is technically backward-compatible; it isn't an API violation to update the lighting when doing so is not required.

I ran the benchmarks provided in #578 and noticed no change in performance between the new and old code.

You can apply the following patch to see the issue for yourself. Try turning a mese block on and off in the dead of night. Without this PR, the lighting will not update when the mese block turns off, provided `find_light_update_conductors` iterates over `default:mese` before `mesecons_extrawires:mese_powered`.

```patch
diff --git a/mesecons_extrawires/mesewire.lua b/mesecons_extrawires/mesewire.lua
index 519129f..7a3d922 100644
--- a/mesecons_extrawires/mesewire.lua
+++ b/mesecons_extrawires/mesewire.lua
@@ -20,10 +20,10 @@ minetest.override_item("default:mese", {
 -- and brighten texture tiles to indicate mese is powered
 local powered_def = mesecon.merge_tables(minetest.registered_nodes["default:mese"], {
 	drop = "default:mese",
-	light_source = 5,
+	light_source = 14,
 	mesecons = {conductor = {
 		state = mesecon.state.on,
-		offstate = "default:mese",
+		offstate = "mesecons_extrawires:mese",
 		rules = mesewire_rules
 	}},
 	groups = {cracky = 1, not_in_creative_inventory = 1},
@@ -35,3 +35,4 @@ for i, v in pairs(powered_def.tiles) do
 end
 
 minetest.register_node("mesecons_extrawires:mese_powered", powered_def)
+minetest.register_alias("mesecons_extrawires:mese", "default:mese")
```