### PR TITLE
Store gate inputs in param2 instead of metadata

### DIFF
--- a/mesecons_gates/init.lua
+++ b/mesecons_gates/init.lua
@@ -23,16 +23,18 @@ local gate_get_input_rules_twoinputs = mesecon.horiz_rules_getter({
 local function set_gate(pos, node, state)
 	local gate = minetest.registered_nodes[node.name]
 
-	if mesecon.do_overheat(pos) then
-		minetest.remove_node(pos)
-		mesecon.receptor_off(pos, gate_get_output_rules(node))
-		minetest.add_item(pos, gate.drop)
-	elseif state then
-		minetest.swap_node(pos, {name = gate.onstate, param2=node.param2})
-		mesecon.receptor_on(pos, gate_get_output_rules(node))
-	else
-		minetest.swap_node(pos, {name = gate.offstate, param2=node.param2})
-		mesecon.receptor_off(pos, gate_get_output_rules(node))
+	local new_nodename = state and gate.onstate or gate.offstate
+	minetest.swap_node(pos, {name = new_nodename, param2 = node.param2})
+	if new_nodename ~= node.name then
+		if mesecon.do_overheat(pos) then
+			minetest.remove_node(pos)
+			mesecon.receptor_off(pos, gate_get_output_rules(node))
+			minetest.add_item(pos, gate.drop)
+		elseif state then
+			mesecon.receptor_on(pos, gate_get_output_rules(node))
+		else
+			mesecon.receptor_off(pos, gate_get_output_rules(node))
+		end
 	end
 end
 

--- a/mesecons_gates/init.lua
+++ b/mesecons_gates/init.lua
@@ -62,9 +62,9 @@ local function update_gate(pos, node, link, newstate)
 			local meta = minetest.get_meta(pos)
 			if link.name == "input1" then
 				val1 = newstate == "on"
-				val2 = meta:get("input2") == "1"
+				val2 = meta:get_int("input2") == 1
 			else
-				val1 = meta:get("input1") == "1"
+				val1 = meta:get_int("input1") == 1
 				val2 = newstate == "on"
 			end
 			-- Set bit 5 so this won't happen again.


### PR DESCRIPTION
All logic gates have paramtype2 = "facedir". The upper three bits of param2 are therefore unused. However, instead of using these bits to store inputs, binary logic gates store their inputs in metadata, using more than 14 extra bytes of storage per logic gate node. This PR aims to change that in a backward-compatible way.

When a binary logic gate is updated, bit 5 of its param2 is checked. Bit 5 being set to 1 indicates that the logic gate is using the new implementation. In this case, bit 6 is the value of input1 and bit 7 is the value of input2. If bit 5 is 0, then the logic gate is either old or has just been placed. In this case, the binary logic gate gets migrated to the new implementation. Bit 5 is then set and the metadata is cleared if it is present.

I decided not to use LBMs to do the migration. Since LBMs run when a block gets activated, they are not suitable for circuit components. While Mesecons is executing, it may load mapblocks and make use of the circuit components inside them without activating the mapblocks. This means that LBMs may not run when they are needed.

Here's a benchmark: [ors.we.gz](https://github.com/minetest-mods/mesecons/files/7936581/ors.we.gz). The line of OR gates whose switch is marked "old" by the sign on top should only be used without the patch applied. The line marked "new" should only be used with the patch applied. The new version seems to be about the same speed, but I didn't benchmark too carefully.

---

I also fixed https://github.com/minetest-mods/mesecons/issues/569 with regards to logic gates. Binary gates no longer overheat just by being pushed.