### PR TITLE
Move default dependency to individual mods that need it

### DIFF
--- a/mesecons/mod.conf
+++ b/mesecons/mod.conf
@@ -1,2 +1,4 @@
 name = mesecons
-depends = default
+# default is an optional dependency as some mods may expect it as a transitory
+# dependency when they depend on mesecons.
+optional_depends = default

--- a/mesecons_blinkyplant/mod.conf
+++ b/mesecons_blinkyplant/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_blinkyplant
-depends = mesecons
+depends = default, mesecons

--- a/mesecons_button/mod.conf
+++ b/mesecons_button/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_button
-depends = mesecons, mesecons_receiver
+depends = default, mesecons, mesecons_receiver

--- a/mesecons_commandblock/mod.conf
+++ b/mesecons_commandblock/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_commandblock
-depends = mesecons
+depends = default, mesecons

--- a/mesecons_delayer/mod.conf
+++ b/mesecons_delayer/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_delayer
-depends = mesecons
+depends = default, mesecons

--- a/mesecons_detector/mod.conf
+++ b/mesecons_detector/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_detector
-depends = mesecons, mesecons_materials
+depends = default, mesecons, mesecons_materials

--- a/mesecons_fpga/mod.conf
+++ b/mesecons_fpga/mod.conf
@@ -1,3 +1,3 @@
 name = mesecons_fpga
-depends = mesecons
+depends = default, mesecons
 optional_depends = screwdriver

--- a/mesecons_gates/mod.conf
+++ b/mesecons_gates/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_gates
-depends = mesecons, mesecons_microcontroller, mesecons_delayer, mesecons_torch, mesecons_materials
+depends = default, mesecons, mesecons_microcontroller, mesecons_delayer, mesecons_torch, mesecons_materials

--- a/mesecons_hydroturbine/mod.conf
+++ b/mesecons_hydroturbine/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_hydroturbine
-depends = mesecons
+depends = default, mesecons

--- a/mesecons_insulated/mod.conf
+++ b/mesecons_insulated/mod.conf
@@ -1,3 +1,3 @@
 name = mesecons_insulated
-depends = mesecons
+depends = default, mesecons
 optional_depends = screwdriver

--- a/mesecons_lamp/mod.conf
+++ b/mesecons_lamp/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_lamp
-depends = mesecons
+depends = default, mesecons

--- a/mesecons_lightstone/mod.conf
+++ b/mesecons_lightstone/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_lightstone
-depends = mesecons, dye
+depends = default, mesecons, dye

--- a/mesecons_luacontroller/mod.conf
+++ b/mesecons_luacontroller/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_luacontroller
-depends = mesecons
+depends = default, mesecons

--- a/mesecons_materials/mod.conf
+++ b/mesecons_materials/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_materials
-depends = mesecons
+depends = default, mesecons

--- a/mesecons_microcontroller/mod.conf
+++ b/mesecons_microcontroller/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_microcontroller
-depends = mesecons
+depends = default, mesecons

--- a/mesecons_movestones/mod.conf
+++ b/mesecons_movestones/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_movestones
-depends = mesecons, mesecons_materials, mesecons_mvps
+depends = default, mesecons, mesecons_materials, mesecons_mvps

--- a/mesecons_noteblock/mod.conf
+++ b/mesecons_noteblock/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_noteblock
-depends = mesecons
+depends = default, mesecons

--- a/mesecons_pistons/mod.conf
+++ b/mesecons_pistons/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_pistons
-depends = mesecons, mesecons_mvps
+depends = default, mesecons, mesecons_mvps

--- a/mesecons_powerplant/mod.conf
+++ b/mesecons_powerplant/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_powerplant
-depends = mesecons
+depends = default, mesecons

--- a/mesecons_pressureplates/mod.conf
+++ b/mesecons_pressureplates/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_pressureplates
-depends = mesecons
+depends = default, mesecons

--- a/mesecons_random/mod.conf
+++ b/mesecons_random/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_random
-depends = mesecons
+depends = default, mesecons

--- a/mesecons_receiver/mod.conf
+++ b/mesecons_receiver/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_receiver
-depends = mesecons
+depends = default, mesecons

--- a/mesecons_solarpanel/mod.conf
+++ b/mesecons_solarpanel/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_solarpanel
-depends = mesecons, mesecons_materials
+depends = default, mesecons, mesecons_materials

--- a/mesecons_stickyblocks/mod.conf
+++ b/mesecons_stickyblocks/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_stickyblocks
-depends = mesecons, mesecons_mvps
+depends = default, mesecons, mesecons_mvps

--- a/mesecons_switch/mod.conf
+++ b/mesecons_switch/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_switch
-depends = mesecons
+depends = default, mesecons

--- a/mesecons_torch/mod.conf
+++ b/mesecons_torch/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_torch
-depends = mesecons
+depends = default, mesecons

--- a/mesecons_walllever/mod.conf
+++ b/mesecons_walllever/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_walllever
-depends = mesecons, mesecons_receiver
+depends = default, mesecons, mesecons_receiver

--- a/mesecons_wires/mod.conf
+++ b/mesecons_wires/mod.conf
@@ -1,2 +1,2 @@
 name = mesecons_wires
-depends = mesecons
+depends = default, mesecons


### PR DESCRIPTION
It was not needed. It is now an optional dependency, so that mods which expect to gain default as a transitive dependency by depending on mesecons won't break. However, default has been added as a direct dependency where appropriate within the modpack.