### PR TITLE
Basically remove mvps_process_stack

### DIFF
--- a/mesecons_mvps/init.lua
+++ b/mesecons_mvps/init.lua
@@ -47,10 +47,8 @@ local function on_mvps_move(moved_nodes)
 end
 
 function mesecon.mvps_process_stack(stack)
-	-- update mesecons for placed nodes ( has to be done after all nodes have been added )
-	for _, n in ipairs(stack) do
-		mesecon.on_placenode(n.pos, minetest.get_node(n.pos))
-	end
+	-- This function is kept for compatibility.
+	-- It used to call on_placenode on the moved nodes, but that is now done automatically.
 end
 
 -- tests if the node can be pushed into, e.g. air, water, grass

--- a/mesecons_pistons/init.lua
+++ b/mesecons_pistons/init.lua
@@ -93,7 +93,6 @@ local piston_on = function(pos, node)
 	minetest.swap_node(pos, {param2 = node.param2, name = pistonspec.onname})
 	minetest.set_node(pusher_pos, {param2 = node.param2, name = pistonspec.pusher})
 	minetest.sound_play("piston_extend", { pos = pos, max_hear_distance = 20, gain = 0.3 }, true)
-	mesecon.mvps_process_stack(stack)
 	mesecon.mvps_move_objects(pusher_pos, dir, oldstack)
 end
 


### PR DESCRIPTION
The other calls to `mvps_process_stack` in mesecons_pistons seem to have been removed before this.

I also removed the body of `mvps_process_stack` itself, as calling it is always redundant. The function still exists, but it does nothing. It is kept in case any external mods are using that part of the API.

This may improve the performance of piston pushing a bit.