### PR TITLE
Protect server against Luacontroller memory usage

### DIFF
--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -672,8 +672,6 @@ local function run_inner(pos, code, event)
 	if type(env.port) ~= "table" then
 		return false, "Ports set are invalid."
 	end
-	local success, memstring = pcall(serialize_memory, env.mem)
-	if not success then return false, memstring end -- memstring is the error message here.
 
 	-- Actually set the ports
 	set_port_states(pos, env.port)

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -24,6 +24,11 @@ mesecon.luacontroller_digiline_maxlen (Digiline message size limit) int 50000 10
 mesecon.luacontroller_maxevents (Controller execution time limit) int 10000 1000 100000
 mesecon.luacontroller_memsize (Controller memory limit) int 100000 10000 1000000
 
+# The amount of server memory a controller is allowed, measured in kilobytes.
+# This actually measures the memory usage after the script is done, not during its runtime.
+# Thus, controllers can lag the server even with a low limit.
+mesecon.luacontroller_volatile_mem_limit (Controller volatile memory limit) int 2000 10 10000000
+
 # Use node timer for interrupts (runs in active blocks only).
 # IID is ignored and at most one interrupt may be queued if this setting is enabled.
 mesecon.luacontroller_lightweight_interrupts (Lightweight interrupts) bool false


### PR DESCRIPTION
If an OOM error occurs within controller code, it is caught and the server does not crash. However, if the controller uses up almost all the memory then puts a lot of data in the persistent storage, the server can crash while serializing the persistent storage. This PR introduces a limit on volatile memory usage. This can only be checked after the luacontroller finishes running, so it can't prevent server lag. However, it can prevent crashes. In addition, after an OOM condition is caught, the garbage collector is run in order to prevent an OOM error a moment later. The default memory limit is 2MB.

I don't run any public servers, so people who do should decide whether this PR is actually useful.