### PR TITLE
Fix VM light update issue

### DIFF
--- a/mesecons/util.lua
+++ b/mesecons/util.lua
@@ -395,7 +395,10 @@ end
 --
 -- The swap will necessitate a light update unless update_light equals false.
 function mesecon.vm_swap_node(pos, name, update_light)
+	-- If one node needs a light update, all VMs should use light updates to
+	-- prevent newly calculated light from being overwritten by other VMs.
 	vm_update_light = vm_update_light or update_light ~= false
+
 	local tbl = vm_get_or_create_entry(pos)
 	local index = tbl.va:indexp(pos)
 	tbl.data[index] = minetest.get_content_id(name)


### PR DESCRIPTION
Sorry, I realized my PR https://github.com/minetest-mods/mesecons/pull/578 had another bug. It can cause things like this:
![screenshot_20220210_161644](https://user-images.githubusercontent.com/28828704/153507044-b5e7482f-e129-43ad-a8d0-5db76736dff6.png)

You can see that the light cuts off sharply. To replicate this yourself, set the powered mese block light source to 14, then make a wire where regular conductors follow a mese block. The regular conductors should extend to the next mapblock. When the wire is powered such that the mese block is powered first, you will see an affect like that in the picture.

To fix this, I made it so that any conductor that needs a light update will make all VMs in the transaction use light updates. This PR should not cause any performance degradation on the fast path. I have not noticed any.

When testing, I recommend applying the following patch to make sure light updates are only used when necessary.

```patch
diff --git a/mesecons/util.lua b/mesecons/util.lua
index 55a0d63..3c4027b 100644
--- a/mesecons/util.lua
+++ b/mesecons/util.lua
@@ -343,6 +343,7 @@ end
 -- Finishes a VoxelManipulator-based transaction, freeing the VMs and map data
 -- and writing back any modified areas.
 function mesecon.vm_commit()
+	if vm_update_light then minetest.chat_send_all("update light") end
 	for hash, tbl in pairs(vm_cache) do
 		if tbl.dirty then
 			local vm = tbl.vm
```