### PR TITLE
Prevent extra pin events with luacontrollers, microcontrollers, and FPGAs

### DIFF
--- a/mesecons_fpga/init.lua
+++ b/mesecons_fpga/init.lua
@@ -114,8 +114,9 @@ plg.register_nodes({
 		effector = {
 			rules = {}, -- replaced later
 			action_change = function(pos, _, rule, newstate)
-				plg.ports_changed(pos, rule, newstate)
-				plg.update(pos)
+				if plg.ports_changed(pos, rule, newstate) then
+					plg.update(pos)
+				end
 			end
 		}
 	},
@@ -327,7 +328,7 @@ plg.update = function(pos)
 end
 
 plg.ports_changed = function(pos, rule, newstate)
-	if rule == nil then return end
+	if rule == nil then return false end
 	local meta = minetest.get_meta(pos)
 	local states
 
@@ -347,10 +348,14 @@ plg.ports_changed = function(pos, rule, newstate)
 	local portno = ({4, 1, nil, 3, 2})[3 + rule.x + 2*rule.z]
 	states[portno] = (newstate == "on")
 
-	meta:set_string("portstates",
+	local new_portstates =
 			(states[1] and "1" or "0") .. (states[2] and "1" or "0") ..
 			(states[3] and "1" or "0") .. (states[4] and "1" or "0")
-	)
+	if new_portstates ~= s then
+		meta:set_string("portstates", new_portstates)
+		return true
+	end
+	return false
 end
 
 plg.getports = function(pos) -- gets merged states of INPUT & OUTPUT

--- a/mesecons_fpga/init.lua
+++ b/mesecons_fpga/init.lua
@@ -327,6 +327,8 @@ plg.update = function(pos)
 	plg.setports(pos, A, B, C, D)
 end
 
+-- Updates the port states according to the signal change.
+-- Returns whether the port states actually changed.
 plg.ports_changed = function(pos, rule, newstate)
 	if rule == nil then return false end
 	local meta = minetest.get_meta(pos)

--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -47,9 +47,10 @@ local function update_real_port_states(pos, rule_name, new_state)
 	local meta = minetest.get_meta(pos)
 	if rule_name == nil then
 		meta:set_int("real_portstates", 1)
-		return
+		return true
 	end
-	local n = meta:get_int("real_portstates") - 1
+	local real_portstates = meta:get_int("real_portstates")
+	local n = real_portstates - 1
 	local L = {}
 	for i = 1, 4 do
 		L[i] = n % 2
@@ -66,12 +67,12 @@ local function update_real_port_states(pos, rule_name, new_state)
 		local port = pos_to_side[rule_name.x + (2 * rule_name.z) + 3]
 		L[port] = (new_state == "on") and 1 or 0
 	end
-	meta:set_int("real_portstates",
-		1 +
-		1 * L[1] +
-		2 * L[2] +
-		4 * L[3] +
-		8 * L[4])
+	local new_portstates = 1 + 1 * L[1] + 2 * L[2] + 4 * L[3] + 8 * L[4]
+	if new_portstates ~= real_portstates then
+		meta:set_int("real_portstates", new_portstates)
+		return true
+	end
+	return false
 end
 
 
@@ -826,8 +827,9 @@ for d = 0, 1 do
 		effector = {
 			rules = input_rules[cid],
 			action_change = function (pos, _, rule_name, new_state)
-				update_real_port_states(pos, rule_name, new_state)
-				run(pos, {type=new_state, pin=rule_name})
+				if update_real_port_states(pos, rule_name, new_state) then
+					run(pos, {type=new_state, pin=rule_name})
+				end
 			end,
 		},
 		receptor = {

--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -43,6 +43,8 @@ local rules = {
 ------------------
 -- These helpers are required to set the port states of the luacontroller
 
+-- Updates the real port states according to the signal change.
+-- Returns whether the real port states actually changed.
 local function update_real_port_states(pos, rule_name, new_state)
 	local meta = minetest.get_meta(pos)
 	if rule_name == nil then

--- a/mesecons_microcontroller/init.lua
+++ b/mesecons_microcontroller/init.lua
@@ -656,6 +656,8 @@ yc.set_portstate = function(port, state, L)
 	return L
 end
 
+-- Updates the real port states according to the signal change.
+-- Returns whether the real port states actually changed.
 yc.update_real_portstates = function(pos, _, rulename, newstate)
 	local meta = minetest.get_meta(pos)
 	if rulename == nil then

--- a/mesecons_microcontroller/init.lua
+++ b/mesecons_microcontroller/init.lua
@@ -44,8 +44,9 @@ local mesecons = {effector =
 {
 	rules = input_rules,
 	action_change = function (pos, node, rulename, newstate)
-		yc.update_real_portstates(pos, node, rulename, newstate)
-		yc.update(pos)
+		if yc.update_real_portstates(pos, node, rulename, newstate) then
+			yc.update(pos)
+		end
 	end
 }}
 if nodename ~= "mesecons_microcontroller:microcontroller0000" then
@@ -659,9 +660,10 @@ yc.update_real_portstates = function(pos, _, rulename, newstate)
 	local meta = minetest.get_meta(pos)
 	if rulename == nil then
 		meta:set_int("real_portstates", 1)
-		return
+		return true
 	end
-	local n = meta:get_int("real_portstates") - 1
+	local real_portstates = meta:get_int("real_portstates")
+	local n = real_portstates - 1
 	local L = {}
 	for i = 1, 4 do
 		L[i] = n%2
@@ -676,7 +678,12 @@ yc.update_real_portstates = function(pos, _, rulename, newstate)
 		local port = ({4, 1, nil, 3, 2})[rulename.x+2*rulename.z+3]
 		L[port] = (newstate == "on") and 1 or 0
 	end
-	meta:set_int("real_portstates", 1 + L[1] + 2*L[2] + 4*L[3] + 8*L[4])
+	local new_portstates = 1 + L[1] + 2*L[2] + 4*L[3] + 8*L[4]
+	if new_portstates ~= real_portstates then
+		meta:set_int("real_portstates", new_portstates)
+		return true
+	end
+	return false
 end
 
 yc.get_real_portstates = function(pos) -- determine if ports are powered (by itself or from outside)


### PR DESCRIPTION
Fixes https://github.com/minetest-mods/mesecons/issues/569.

These devices now only run their code when `action_change` actually changes the state of a port.

I have tested this with circuits from Mesecons Lab.

@Makefile-dot-in, does this fix your issue?