### PR TITLE
Move objects even when sticky blocks are involved

### DIFF
--- a/mesecons_mvps/init.lua
+++ b/mesecons_mvps/init.lua
@@ -364,7 +364,7 @@ function mesecon.mvps_move_objects(pos, dir, nodestack, movefactor)
 				local min_pos = vector.offset(obj_pos, cbox[1] + 0.01, cbox[2] + 0.01, cbox[3] + 0.01)
 				local max_pos = vector.offset(obj_pos, cbox[4] - 0.01, cbox[5] - 0.01, cbox[6] - 0.01)
 				if not area_intersects_nodes(vector.add(min_pos, dir), vector.add(max_pos, dir)) or
-						area_intersects_nodes(min_pos, max_pos, moved_positions) then
+						(nodestack[1] ~= nil and area_intersects_nodes(min_pos, max_pos, moved_positions)) then
 					obj:move_to(vector.add(obj_pos, dir))
 				end
 			end


### PR DESCRIPTION
Fixes https://github.com/minetest-mods/mesecons/issues/596. Fixes https://github.com/minetest-mods/mesecons/issues/462.

This significantly complicates the code. I had to add some special cases to replicate the old behavior. For example, when a sticky piston retracts while pulling no blocks, only objects touching the face of the piston head should be pulled. I could simplify the code if this behavior does not need preservation. One thing that did change in the pulling of objects is that mvps no longer pull objects downwards. I think the new behavior is more consistent with the lack of pulling in other directions, although it could affect elevators a bit.

Objects are still dragged on the sides of moving stacks, but no longer are dragged into solid nodes.