### PR TITLE
Consolidate horizontal rules getters

### DIFF
--- a/mesecons/util.lua
+++ b/mesecons/util.lua
@@ -72,7 +72,28 @@ function mesecon.rotate_rules_up(rules)
 	end
 	return nr
 end
---
+
+-- Returns a rules getter function that returns different rules depending on the node's horizontal rotation.
+-- If param2 % 4 == 0, then the rules returned by the getter are a copy of base_rules.
+function mesecon.horiz_rules_getter(base_rules)
+	local rotations = {mesecon.tablecopy(base_rules)}
+	for i = 2, 4 do
+		local right_rules = rotations[i - 1]
+		if not right_rules[1] or right_rules[1].x then
+			-- flat rules
+			rotations[i] = mesecon.rotate_rules_left(right_rules)
+		else
+			-- not flat
+			rotations[i] = {}
+			for j, rules in ipairs(right_rules) do
+				rotations[i][j] = mesecon.rotate_rules_left(rules)
+			end
+		end
+	end
+	return function(node)
+		return rotations[node.param2 % 4 + 1]
+	end
+end
 
 function mesecon.flattenrules(allrules)
 --[[

--- a/mesecons_delayer/init.lua
+++ b/mesecons_delayer/init.lua
@@ -1,19 +1,7 @@
 -- Function that get the input/output rules of the delayer
-local delayer_get_output_rules = function(node)
-	local rules = {{x = 0, y = 0, z = 1}}
-	for i = 0, node.param2 do
-		rules = mesecon.rotate_rules_left(rules)
-	end
-	return rules
-end
+local delayer_get_output_rules = mesecon.horiz_rules_getter({{x = 1, y = 0, z = 0}})
 
-local delayer_get_input_rules = function(node)
-	local rules = {{x = 0, y = 0, z = -1}}
-	for i = 0, node.param2 do
-		rules = mesecon.rotate_rules_left(rules)
-	end
-	return rules
-end
+local delayer_get_input_rules = mesecon.horiz_rules_getter({{x = -1, y = 0, z = 0}})
 
 -- Functions that are called after the delay time
 

--- a/mesecons_extrawires/corner.lua
+++ b/mesecons_extrawires/corner.lua
@@ -3,17 +3,10 @@ local corner_selectionbox = {
 		fixed = { -16/32, -16/32, -16/32, 5/32, -12/32, 5/32 },
 }
 
-local corner_get_rules = function (node)
-	local rules =
-	{{x = 1,  y = 0,  z =  0},
-	 {x = 0,  y = 0,  z = -1}}
-
-	for i = 0, node.param2 do
-		rules = mesecon.rotate_rules_left(rules)
-	end
-
-	return rules
-end
+local corner_get_rules = mesecon.horiz_rules_getter({
+	{x = 0, y = 0, z = -1},
+	{x = -1, y = 0, z = 0},
+})
 
 minetest.register_node("mesecons_extrawires:corner_on", {
 	drawtype = "mesh",

--- a/mesecons_extrawires/doublecorner.lua
+++ b/mesecons_extrawires/doublecorner.lua
@@ -3,7 +3,7 @@ local doublecorner_selectionbox = {
 	fixed = { -8/16, -8/16, -8/16, 8/16, -6/16, 8/16 },
 }
 
-local rules = {
+local doublecorner_get_rules = mesecon.horiz_rules_getter({
 	{
 		{ x = 1, y = 0, z = 0 },
 		{ x = 0, y = 0, z = 1 },
@@ -12,19 +12,7 @@ local rules = {
 		{ x = -1, y = 0, z = 0 },
 		{ x = 0, y = 0, z = -1 },
 	},
-}
-
-local doublecorner_rules = {}
-for k = 1, 4 do
-	doublecorner_rules[k] = table.copy(rules)
-	for i, r in ipairs(rules) do
-		rules[i] = mesecon.rotate_rules_left(r)
-	end
-end
-
-local function doublecorner_get_rules(node)
-	return doublecorner_rules[node.param2 % 4 + 1]
-end
+})
 
 local doublecorner_states = {
 	"mesecons_extrawires:doublecorner_00",

--- a/mesecons_extrawires/tjunction.lua
+++ b/mesecons_extrawires/tjunction.lua
@@ -10,18 +10,11 @@ local tjunction_selectionbox = {
 		fixed = { -16/32, -16/32, -16/32, 16/32, -12/32, 7/32 },
 }
 
-local tjunction_get_rules = function (node)
-	local rules =
-	{{x = 0,  y = 0,  z =  1},
-	 {x = 1,  y = 0,  z =  0},
-	 {x = 0,  y = 0,  z = -1}}
-
-	for i = 0, node.param2 do
-		rules = mesecon.rotate_rules_left(rules)
-	end
-
-	return rules
-end
+local tjunction_get_rules = mesecon.horiz_rules_getter({
+	{x = 1, y = 0, z = 0},
+	{x = 0, y = 0, z = -1},
+	{x = -1, y = 0, z = 0},
+})
 
 minetest.register_node("mesecons_extrawires:tjunction_on", {
 	drawtype = "nodebox",

--- a/mesecons_gates/init.lua
+++ b/mesecons_gates/init.lua
@@ -11,25 +11,14 @@ local nodebox = {
 	},
 }
 
-local function gate_rotate_rules(node, rules)
-	for rotations = 0, node.param2 - 1 do
-		rules = mesecon.rotate_rules_left(rules)
-	end
-	return rules
-end
+local gate_get_output_rules = mesecon.horiz_rules_getter({{x = 1, y = 0, z = 0}})
 
-local function gate_get_output_rules(node)
-	return gate_rotate_rules(node, {{x=1, y=0, z=0}})
-end
+local gate_get_input_rules_oneinput = mesecon.horiz_rules_getter({{x =-1, y = 0, z = 0}})
 
-local function gate_get_input_rules_oneinput(node)
-	return gate_rotate_rules(node, {{x=-1, y=0, z=0}})
-end
-
-local function gate_get_input_rules_twoinputs(node)
-	return gate_rotate_rules(node, {{x=0, y=0, z=1, name="input1"},
-		{x=0, y=0, z=-1, name="input2"}})
-end
+local gate_get_input_rules_twoinputs = mesecon.horiz_rules_getter({
+	{x = 0, y = 0, z = 1, name = "input1"},
+	{x = 0, y = 0, z = -1, name = "input2"},
+})
 
 local function set_gate(pos, node, state)
 	local gate = minetest.registered_nodes[node.name]

--- a/mesecons_insulated/init.lua
+++ b/mesecons_insulated/init.lua
@@ -1,11 +1,7 @@
-local function insulated_wire_get_rules(node)
-	local rules = 	{{x = 1,  y = 0,  z = 0},
-			 {x =-1,  y = 0,  z = 0}}
-	if node.param2 == 1 or node.param2 == 3 then
-		return mesecon.rotate_rules_right(rules)
-	end
-	return rules
-end
+local insulated_wire_get_rules = mesecon.horiz_rules_getter({
+	{x = 1, y = 0, z = 0},
+	{x = -1, y = 0, z = 0},
+})
 
 minetest.register_node("mesecons_insulated:insulated_on", {
 	drawtype = "nodebox",

--- a/mesecons_receiver/init.lua
+++ b/mesecons_receiver/init.lua
@@ -25,18 +25,10 @@ local up_rcvboxes = {
 	{6/16,  -8/16, 1/16,  8/16, -7/16, -1/16}, -- Plate extension (East)
 }
 
-local receiver_get_rules = function (node)
-	local rules = {	{x =  1, y = 0, z = 0},
-			{x = -2, y = 0, z = 0}}
-	if node.param2 == 2 then
-		rules = mesecon.rotate_rules_left(rules)
-	elseif node.param2 == 3 then
-		rules = mesecon.rotate_rules_right(mesecon.rotate_rules_right(rules))
-	elseif node.param2 == 0 then
-		rules = mesecon.rotate_rules_right(rules)
-	end
-	return rules
-end
+local receiver_get_rules = mesecon.horiz_rules_getter({
+	{x = 0, y = 0, z = 1},
+	{x = 0, y = 0, z = -2},
+})
 
 mesecon.register_node("mesecons_receiver:receiver", {
 	drawtype = "nodebox",


### PR DESCRIPTION
There are several different components that can be rotated around the Y axis. This PR consolidates all their rules getter functions using a new API function. This has the added benefit of making them all use lookup tables instead of repeated rotation, which is probably faster and creates less garbage. I think I have noticed a minor performance increase.

I have tested that the affected nodes still work, but it would be good if someone could verify this.