### PR TITLE
Fix error prone negation reported by luacheck

### DIFF
--- a/mesecons_doors/init.lua
+++ b/mesecons_doors/init.lua
@@ -1,7 +1,7 @@
 -- Modified, from minetest_game/mods/doors/init.lua
 local function on_rightclick(pos, dir, check_name, replace, replace_dir, params)
 	pos.y = pos.y + dir
-	if not minetest.get_node(pos).name == check_name then
+	if minetest.get_node(pos).name ~= check_name then
 		return
 	end
 	local p2 = minetest.get_node(pos).param2


### PR DESCRIPTION
Trivial.

If you installed luacheck using luarocks, you might have to upgrade it. Using `install` again worked for me.