### PR TITLE
Remove some unneeded memory allocation

### DIFF
--- a/mesecons/init.lua
+++ b/mesecons/init.lua
@@ -77,8 +77,8 @@ mesecon.queue:add_function("receptor_on", function (pos, rules)
 	-- Call turnon on all linking positions
 	for _, rule in ipairs(mesecon.flattenrules(rules)) do
 		local np = vector.add(pos, rule)
-		local rulenames = mesecon.rules_link_rule_all(pos, rule)
-		for _, rulename in ipairs(rulenames) do
+		local rulename = mesecon.link(pos, np)
+		if rulename then
 			mesecon.turnon(np, rulename)
 		end
 	end
@@ -96,8 +96,8 @@ mesecon.queue:add_function("receptor_off", function (pos, rules)
 	-- Call turnoff on all linking positions
 	for _, rule in ipairs(mesecon.flattenrules(rules)) do
 		local np = vector.add(pos, rule)
-		local rulenames = mesecon.rules_link_rule_all(pos, rule)
-		for _, rulename in ipairs(rulenames) do
+		local rulename = mesecon.link(pos, np)
+		if rulename then
 			mesecon.vm_begin()
 			mesecon.changesignal(np, minetest.get_node(np), rulename, mesecon.state.off, 2)
 

--- a/mesecons/internal.lua
+++ b/mesecons/internal.lua
@@ -59,6 +59,10 @@ end
 local function get_rules(def, node)
 	local rules = def.rules
 	if type(rules) == 'function' then
+		if not def.const_node then
+			-- Copy the node to avoid overwriting data in the cache
+			node = {name = node.name, param1 = node.param1, param2 = node.param2}
+		end
 		return rules(node)
 	elseif rules then
 		return rules
@@ -336,7 +340,7 @@ end
 -- some more general high-level stuff
 
 function mesecon.is_power_on(pos, rulename)
-	local node = mesecon.get_node_force(pos)
+	local node = mesecon.get_node_force_nocopy(pos)
 	if node and (mesecon.is_conductor_on(node, rulename) or mesecon.is_receptor_on(node.name)) then
 		return true
 	end
@@ -344,7 +348,7 @@ function mesecon.is_power_on(pos, rulename)
 end
 
 function mesecon.is_power_off(pos, rulename)
-	local node = mesecon.get_node_force(pos)
+	local node = mesecon.get_node_force_nocopy(pos)
 	if node and (mesecon.is_conductor_off(node, rulename) or mesecon.is_receptor_off(node.name)) then
 		return true
 	end
@@ -410,7 +414,7 @@ function mesecon.turnon(pos, link)
 
 	local depth = 1
 	for f in frontiers:iter() do
-		local node = mesecon.get_node_force(f.pos)
+		local node = mesecon.get_node_force_nocopy(f.pos)
 
 		if not node then
 			-- Area does not exist; do nothing
@@ -475,7 +479,7 @@ function mesecon.turnoff(pos, link)
 
 	local depth = 1
 	for f in frontiers:iter() do
-		local node = mesecon.get_node_force(f.pos)
+		local node = mesecon.get_node_force_nocopy(f.pos)
 
 		if not node then
 			-- Area does not exist; do nothing
@@ -492,7 +496,7 @@ function mesecon.turnoff(pos, link)
 						-- abort this turnoff process by returning false. `receptor_off` will
 						-- discard all the changes that we made in the voxelmanip:
 						if mesecon.link_inverted(f.pos, np) then
-							if mesecon.is_receptor_on(mesecon.get_node_force(np).name) then
+							if mesecon.is_receptor_on(mesecon.get_node_force_nocopy(np).name) then
 								return false
 							end
 						end
@@ -538,7 +542,7 @@ end
 -- Get the linking inputrule of inputnode (effector or conductor) that is connected to
 -- outputnode (receptor or conductor) between positions `output` and `input`
 function mesecon.link(output, input)
-	local inputnode = mesecon.get_node_force(input)
+	local inputnode = mesecon.get_node_force_nocopy(input)
 	local inputrules = mesecon.get_any_inputrules(inputnode)
 	if not inputrules then return end
 
@@ -554,7 +558,7 @@ end
 -- Get the linking outputrule of outputnode (receptor or conductor) that is connected to
 -- inputnode (effector or conductor) between positions `input` and `output`
 function mesecon.link_inverted(input, output)
-	local outputnode = mesecon.get_node_force(output)
+	local outputnode = mesecon.get_node_force_nocopy(output)
 	local outputrules = mesecon.get_any_outputrules(outputnode)
 	if not outputrules then return end
 
@@ -567,7 +571,7 @@ function mesecon.link_inverted(input, output)
 end
 
 function mesecon.is_powered(pos, rule)
-	local node = mesecon.get_node_force(pos)
+	local node = mesecon.get_node_force_nocopy(pos)
 	local rules = mesecon.get_any_inputrules(node)
 	if not rules then return false end
 
@@ -579,7 +583,7 @@ function mesecon.is_powered(pos, rule)
 			local rname = mesecon.link_inverted(pos, vector.add(pos, rule))
 			if rname then
 				local np = vector.add(pos, rname)
-				local nn = mesecon.get_node_force(np)
+				local nn = mesecon.get_node_force_nocopy(np)
 
 				if (mesecon.is_conductor_on(nn, mesecon.invertRule(rname))
 				or mesecon.is_receptor_on(nn.name)) then
@@ -591,7 +595,7 @@ function mesecon.is_powered(pos, rule)
 		local rname = mesecon.link_inverted(pos, vector.add(pos, rule))
 		if rname then
 			local np = vector.add(pos, rname)
-			local nn = mesecon.get_node_force(np)
+			local nn = mesecon.get_node_force_nocopy(np)
 			if (mesecon.is_conductor_on (nn, mesecon.invertRule(rname))
 			or mesecon.is_receptor_on (nn.name)) then
 				table.insert(sourcepos, np)

--- a/mesecons/internal.lua
+++ b/mesecons/internal.lua
@@ -580,23 +580,23 @@ function mesecon.is_powered(pos, rule)
 
 	if not rule then
 		for _, rule in ipairs(mesecon.flattenrules(rules)) do
-			local rname = mesecon.link_inverted(pos, vector.add(pos, rule))
+			local np = vector.add(pos, rule)
+			local rname = mesecon.link_inverted(pos, np)
 			if rname then
-				local np = vector.add(pos, rname)
 				local nn = mesecon.get_node_force_nocopy(np)
 
-				if (mesecon.is_conductor_on(nn, mesecon.invertRule(rname))
+				if (mesecon.is_conductor_on(nn, rname)
 				or mesecon.is_receptor_on(nn.name)) then
 					table.insert(sourcepos, np)
 				end
 			end
 		end
 	else
-		local rname = mesecon.link_inverted(pos, vector.add(pos, rule))
+		local np = vector.add(pos, rule)
+		local rname = mesecon.link_inverted(pos, np)
 		if rname then
-			local np = vector.add(pos, rname)
 			local nn = mesecon.get_node_force_nocopy(np)
-			if (mesecon.is_conductor_on (nn, mesecon.invertRule(rname))
+			if (mesecon.is_conductor_on (nn, rname)
 			or mesecon.is_receptor_on (nn.name)) then
 				table.insert(sourcepos, np)
 			end

--- a/mesecons_button/init.lua
+++ b/mesecons_button/init.lua
@@ -55,6 +55,7 @@ minetest.register_node("mesecons_button:button_off", {
 	sounds = mesecon.node_sound.stone,
 	mesecons = {receptor = {
 		state = mesecon.state.off,
+		const_node = true,
 		rules = mesecon.rules.buttonlike_get
 	}},
 	on_blast = mesecon.on_blastnode,
@@ -96,6 +97,7 @@ minetest.register_node("mesecons_button:button_on", {
 	sounds = mesecon.node_sound.stone,
 	mesecons = {receptor = {
 		state = mesecon.state.on,
+		const_node = true,
 		rules = mesecon.rules.buttonlike_get
 	}},
 	on_timer = mesecon.button_turnoff,

--- a/mesecons_delayer/init.lua
+++ b/mesecons_delayer/init.lua
@@ -108,10 +108,12 @@ local off_state = {
 		receptor =
 		{
 			state = mesecon.state.off,
+			const_node = true,
 			rules = delayer_get_output_rules
 		},
 		effector =
 		{
+			const_node = true,
 			rules = delayer_get_input_rules,
 			action_on = delayer_activate
 		}

--- a/mesecons_extrawires/corner.lua
+++ b/mesecons_extrawires/corner.lua
@@ -34,6 +34,7 @@ minetest.register_node("mesecons_extrawires:corner_on", {
 	mesecons = {conductor =
 	{
 		state = mesecon.state.on,
+		const_node = true,
 		rules = corner_get_rules,
 		offstate = "mesecons_extrawires:corner_off"
 	}},
@@ -60,6 +61,7 @@ minetest.register_node("mesecons_extrawires:corner_off", {
 	mesecons = {conductor =
 	{
 		state = mesecon.state.off,
+		const_node = true,
 		rules = corner_get_rules,
 		onstate = "mesecons_extrawires:corner_on"
 	}},

--- a/mesecons_extrawires/doublecorner.lua
+++ b/mesecons_extrawires/doublecorner.lua
@@ -62,6 +62,7 @@ for k, state in ipairs(doublecorner_states) do
 		mesecons = {
 			conductor = {
 				states = doublecorner_states,
+				const_node = true,
 				rules = doublecorner_get_rules,
 			},
 		},

--- a/mesecons_extrawires/tjunction.lua
+++ b/mesecons_extrawires/tjunction.lua
@@ -46,6 +46,7 @@ minetest.register_node("mesecons_extrawires:tjunction_on", {
 	mesecons = {conductor =
 	{
 		state = mesecon.state.on,
+		const_node = true,
 		rules = tjunction_get_rules,
 		offstate = "mesecons_extrawires:tjunction_off"
 	}},
@@ -76,6 +77,7 @@ minetest.register_node("mesecons_extrawires:tjunction_off", {
 	mesecons = {conductor =
 	{
 		state = mesecon.state.off,
+		const_node = true,
 		rules = tjunction_get_rules,
 		onstate = "mesecons_extrawires:tjunction_on"
 	}},

--- a/mesecons_gates/init.lua
+++ b/mesecons_gates/init.lua
@@ -99,8 +99,10 @@ local function register_gate(name, inputnumber, assess, recipe, description)
 		groups = {dig_immediate = 2, overheat = 1},
 		mesecons = { receptor = {
 			state = "off",
+			const_node = true,
 			rules = gate_get_output_rules
 		}, effector = {
+			const_node = true,
 			rules = get_inputrules,
 			action_change = update_gate
 		}}
@@ -118,8 +120,10 @@ local function register_gate(name, inputnumber, assess, recipe, description)
 		groups = {dig_immediate = 2, not_in_creative_inventory = 1, overheat = 1},
 		mesecons = { receptor = {
 			state = "on",
+			const_node = true,
 			rules = gate_get_output_rules
 		}, effector = {
+			const_node = true,
 			rules = get_inputrules,
 			action_change = update_gate
 		}}

--- a/mesecons_insulated/init.lua
+++ b/mesecons_insulated/init.lua
@@ -38,6 +38,7 @@ minetest.register_node("mesecons_insulated:insulated_on", {
 	mesecons = {conductor = {
 		state = mesecon.state.on,
 		offstate = "mesecons_insulated:insulated_off",
+		const_node = true,
 		rules = insulated_wire_get_rules
 	}},
 	on_blast = mesecon.on_blastnode,
@@ -74,6 +75,7 @@ minetest.register_node("mesecons_insulated:insulated_off", {
 	mesecons = {conductor = {
 		state = mesecon.state.off,
 		onstate = "mesecons_insulated:insulated_on",
+		const_node = true,
 		rules = insulated_wire_get_rules
 	}},
 	on_blast = mesecon.on_blastnode,

--- a/mesecons_lamp/init.lua
+++ b/mesecons_lamp/init.lua
@@ -31,6 +31,7 @@ minetest.register_node("mesecons_lamp:lamp_on", {
 		action_off = function (pos, node)
 			minetest.swap_node(pos, {name = "mesecons_lamp:lamp_off", param2 = node.param2})
 		end,
+		const_node = true,
 		rules = mesecon.rules.wallmounted_get,
 	}},
 	on_blast = mesecon.on_blastnode,
@@ -56,6 +57,7 @@ minetest.register_node("mesecons_lamp:lamp_off", {
 		action_on = function (pos, node)
 			minetest.swap_node(pos, {name = "mesecons_lamp:lamp_on", param2 = node.param2})
 		end,
+		const_node = true,
 		rules = mesecon.rules.wallmounted_get,
 	}},
 	on_blast = mesecon.on_blastnode,

--- a/mesecons_pistons/init.lua
+++ b/mesecons_pistons/init.lua
@@ -281,6 +281,7 @@ minetest.register_node("mesecons_pistons:piston_normal_off", {
 	sounds = mesecon.node_sound.wood,
 	mesecons = {effector={
 		action_on = piston_on,
+		const_node = true,
 		rules = piston_get_rules,
 	}},
 	on_punch = piston_punch,
@@ -311,6 +312,7 @@ minetest.register_node("mesecons_pistons:piston_normal_on", {
 	sounds = mesecon.node_sound.wood,
 	mesecons = {effector={
 		action_off = piston_off,
+		const_node = true,
 		rules = piston_get_rules,
 	}},
 	on_rotate = piston_rotate_on,
@@ -360,6 +362,7 @@ minetest.register_node("mesecons_pistons:piston_sticky_off", {
 	sounds = mesecon.node_sound.wood,
 	mesecons = {effector={
 		action_on = piston_on,
+		const_node = true,
 		rules = piston_get_rules,
 	}},
 	on_punch = piston_punch,
@@ -390,6 +393,7 @@ minetest.register_node("mesecons_pistons:piston_sticky_on", {
 	sounds = mesecon.node_sound.wood,
 	mesecons = {effector={
 		action_off = piston_off,
+		const_node = true,
 		rules = piston_get_rules,
 	}},
 	on_rotate = piston_rotate_on,

--- a/mesecons_receiver/init.lua
+++ b/mesecons_receiver/init.lua
@@ -68,6 +68,7 @@ mesecon.register_node("mesecons_receiver:receiver", {
 	},
 	mesecons = {conductor = {
 		state = mesecon.state.off,
+		const_node = true,
 		rules = receiver_get_rules,
 		onstate = "mesecons_receiver:receiver_on"
 	}}

--- a/mesecons_solarpanel/init.lua
+++ b/mesecons_solarpanel/init.lua
@@ -21,12 +21,14 @@ mesecon.register_node("mesecons_solarpanel:solar_panel", {
 	groups = {dig_immediate = 3},
 	mesecons = {receptor = {
 		state = mesecon.state.off,
+		const_node = true,
 		rules = mesecon.rules.wallmounted_get
 	}}
 },{
 	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
 	mesecons = {receptor = {
 		state = mesecon.state.on,
+		const_node = true,
 		rules = mesecon.rules.wallmounted_get
 	}},
 })

--- a/mesecons_torch/init.lua
+++ b/mesecons_torch/init.lua
@@ -67,6 +67,7 @@ minetest.register_node("mesecons_torch:mesecon_torch_off", {
 	sounds = mesecon.node_sound.default,
 	mesecons = {receptor = {
 		state = mesecon.state.off,
+		const_node = true,
 		rules = torch_get_output_rules
 	}},
 	on_blast = mesecon.on_blastnode,

--- a/mesecons_walllever/init.lua
+++ b/mesecons_walllever/init.lua
@@ -34,6 +34,7 @@ mesecon.register_node("mesecons_walllever:wall_lever", {
 	mesh="jeija_wall_lever_off.obj",
 	on_rotate = mesecon.buttonlike_onrotate,
 	mesecons = {receptor = {
+		const_node = true,
 		rules = mesecon.rules.buttonlike_get,
 		state = mesecon.state.off
 	}},
@@ -48,6 +49,7 @@ mesecon.register_node("mesecons_walllever:wall_lever", {
 	mesh="jeija_wall_lever_on.obj",
 	on_rotate = false,
 	mesecons = {receptor = {
+		const_node = true,
 		rules = mesecon.rules.buttonlike_get,
 		state = mesecon.state.on
 	}},


### PR DESCRIPTION
## Overview

This PR does three things:

- Clean up the basic info getters like `mesecon.get_conductor`.
- Speed up the functions for finding node links, remove unnecessary allocations.
  - As far as I can tell there can only be one linking rule between two nodes, so the functions have been simplified.
  - The inverted function now returns the actual rule, not the inverted rule.
- Remove unnecessary node copies.
  - Components in the modpack with rule getter functions are passed non-copied nodes. External components can get non-copied nodes as well by putting the `const_node` key in their definitions.

## Benchmarks

I used the benchmarks from https://github.com/minetest-mods/mesecons/pull/578. Keep in mind that reducing garbage collection load may also increase the performance of code outside mesecons.

### Long line of diodes

Before: 0.11s
After: 0.10s (likely lower just due to random chance)

### Block of wires

I turned the block on and off 10 times.

Before: 1.7s
After: 0.8s

### 256 byte memory bank

Before: 1.5s
After: 1.3s

## Tests

I've done manual testing and things work. The tests from https://github.com/minetest-mods/mesecons/pull/605 also pass.