### PR TITLE
Fix conductor aliases again

### DIFF
--- a/mesecons/internal.lua
+++ b/mesecons/internal.lua
@@ -372,17 +372,33 @@ end
 -- The set of conductor states which require light updates when they change.
 local light_update_conductors
 
--- Calculate the contents of the above set if they have not been calculated.
-local function find_light_update_conductors()
+-- Prepare all conductor content before the first turnon/turnoff:
+-- - Resolve aliases in conductor state lists.
+-- - Calculate the contents of light_update_conductors.
+local function prepare_conductors()
 	-- The expensive calculation is only done the first time.
 	if light_update_conductors then return end
 
 	light_update_conductors = {}
 
-	-- Find conductors whose lighting characteristics change depending on their state.
 	local checked = {}
 	for name, def in pairs(minetest.registered_nodes) do
 		local conductor = mesecon.get_conductor(name)
+
+		-- Resolve aliases in state list.
+		if conductor then
+			if conductor.onstate then
+				conductor.onstate = minetest.registered_aliases[conductor.onstate] or conductor.onstate
+			elseif conductor.offstate then
+				conductor.offstate = minetest.registered_aliases[conductor.offstate] or conductor.offstate
+			else
+				for i, state in ipairs(conductor.states) do
+					conductor.states[i] = minetest.registered_aliases[state] or state
+				end
+			end
+		end
+
+		-- Find conductors whose lighting characteristics change depending on their state.
 		if conductor and not checked[name] then
 			-- Find the other states of the conductor besides the current one.
 			local other_states
@@ -420,7 +436,7 @@ end
 -- Follow all all conductor paths replacing conductors that were already
 -- looked at, activating / changing all effectors along the way.
 function mesecon.turnon(pos, link)
-	find_light_update_conductors()
+	prepare_conductors()
 
 	local frontiers = mesecon.fifo_queue.new()
 	frontiers:add({pos = pos, link = link})
@@ -483,7 +499,7 @@ end
 --	depth = indicates order in which signals wire fired, higher is later
 -- }
 function mesecon.turnoff(pos, link)
-	find_light_update_conductors()
+	prepare_conductors()
 
 	local frontiers = mesecon.fifo_queue.new()
 	frontiers:add({pos = pos, link = link})

--- a/mesecons/util.lua
+++ b/mesecons/util.lua
@@ -403,6 +403,7 @@ function mesecon.vm_get_node(pos)
 end
 
 -- Sets a node’s name during a VoxelManipulator-based transaction.
+-- Aliases may not work correctly.
 --
 -- Existing param1, param2, and metadata are left alone.
 --
@@ -453,6 +454,7 @@ end
 -- the server’s main map data cache and then accessed from there.
 --
 -- Inside a VM transaction, the transaction’s VM cache is used.
+-- Aliases may not work correctly.
 --
 -- This function can only be used to change the node’s name, not its parameters
 -- or metadata.


### PR DESCRIPTION
I think they were broken by https://github.com/minetest-mods/mesecons/pull/600, since the name of a node from the cache may now be an alias. So as not to risk slowing down the oft-called `mesecon.vm_swap_node`, I decided to fix this by resolving any aliases beforehand. This has the added benefit of fixing conductors with more than two states which have aliases in their state lists; before they would crash. The downside is that mesecons specifications may be modified, which is not documented. On the other hand, it isn't documented that they _won't_ be modified, either. Sharing state lists between multiple conductors still works.

The tests from https://github.com/minetest-mods/mesecons/pull/605 pass.