### PR TITLE
Exit with error if vports do not exist for any reason

### DIFF
--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -471,6 +471,7 @@ local safe_globals = {
 local function create_environment(pos, mem, event, itbl, send_warning)
 	-- Gather variables for the environment
 	local vports = minetest.registered_nodes[minetest.get_node(pos).name].virtual_portstates
+	if not vports then return end
 	local vports_copy = {}
 	for k, v in pairs(vports) do vports_copy[k] = v end
 	local rports = get_real_port_states(pos)
@@ -627,6 +628,7 @@ local function run_inner(pos, code, event)
 	-- Create environment
 	local itbl = {}
 	local env = create_environment(pos, mem, event, itbl, send_warning)
+	if not env then return false, "Env does not exist. Controller has been moved?" end
 
 	local success, msg
 	-- Create the sandbox and execute code

--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -470,8 +470,12 @@ local safe_globals = {
 
 local function create_environment(pos, mem, event, itbl, send_warning)
 	-- Gather variables for the environment
-	local vports = minetest.registered_nodes[minetest.get_node(pos).name].virtual_portstates
+	local node_def = minetest.registered_nodes[minetest.get_node(pos).name]
+	if not node_def then return end
+
+	local vports = node_def.virtual_portstates
 	if not vports then return end
+
 	local vports_copy = {}
 	for k, v in pairs(vports) do vports_copy[k] = v end
 	local rports = get_real_port_states(pos)


### PR DESCRIPTION
Saw a fatal error recently when the virtual ports didn't exist for some reason...

```
2022-06-08 00:23:19: ERROR[Main]: ServerError: AsyncErr: environment_Step: Runtime error from mod 'mesecons_luacontroller' in callback environment_Step(): ...bls/bin/../mods/mesecons/mesecons_luacontroller/init.lua:472: bad argument #1 to 'pairs' (table expected, got nil)
2022-06-08 00:23:19: ERROR[Main]: stack traceback:
2022-06-08 00:23:19: ERROR[Main]:     [C]: in function 'pairs'
2022-06-08 00:23:19: ERROR[Main]:     ...bls/bin/../mods/mesecons/mesecons_luacontroller/init.lua:472: in function 'create_environment'
2022-06-08 00:23:19: ERROR[Main]:     ...bls/bin/../mods/mesecons/mesecons_luacontroller/init.lua:627: in function 'run_inner'
2022-06-08 00:23:19: ERROR[Main]:     ...bls/bin/../mods/mesecons/mesecons_luacontroller/init.lua:686: in function 'run'
2022-06-08 00:23:19: ERROR[Main]:     ...bls/bin/../mods/mesecons/mesecons_luacontroller/init.lua:753: in function 'action'
2022-06-08 00:23:19: ERROR[Main]:     /home/billys/bls/bin/../mods/digilines/internal.lua:106: in function 'transmit'
2022-06-08 00:23:19: ERROR[Main]:     /home/billys/bls/bin/../mods/digilines/init.lua:53: in function 'receptor_send'
2022-06-08 00:23:19: ERROR[Main]:     ...bls/bin/../mods/mesecons/mesecons_luacontroller/init.lua:724: in function <...bls/bin/../mods/mesecons/mesecons_luacontroller/init.lua:718>
2022-06-08 00:23:19: ERROR[Main]:     ...billys/bls/bin/../mods/mesecons/mesecons/actionqueue.lua:137: in function 'execute'
2022-06-08 00:23:19: ERROR[Main]:     ...billys/bls/bin/../mods/mesecons/mesecons/actionqueue.lua:111: in function <...billys/bls/bin/../mods/mesecons/mesecons/actionqueue.lua:73>
2022-06-08 00:23:19: ERROR[Main]:     /home/billys/bls/bin/../builtin/game/register.lua:422: in function </home/billys/bls/bin/../builtin/game/register.lua:406>
2022-06-08 00:23:19: ERROR[Main]: stack traceback:
```


My guess is something moved or removed the node, it can't hurt to check if this has occurred unexpectedly and exit safely with an error message