### PR TITLE
add minimum interrupt time to luacontroller to optionally remove hyper-fast signals

### DIFF
--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -316,6 +316,9 @@ if mesecon.setting("luacontroller_lightweight_interrupts", false) then
 	get_interrupt = function(pos, itbl, send_warning)
 		return (function(time, iid)
 			if type(time) ~= "number" then error("Delay must be a number") end
+			if time < mesecon.setting("luacontroller_minimum_interrupt", 1) then
+				error("Delay is too short (min. "..mesecon.setting("luacontroller_minimum_interrupt", 1)..")")
+			end
 			if iid ~= nil then send_warning("Interrupt IDs are disabled on this server") end
 			table.insert(itbl, function() minetest.get_node_timer(pos):start(time) end)
 		end)
@@ -329,6 +332,9 @@ else
 			-- NOTE: This runs within string metatable sandbox, so don't *rely* on anything of the form (""):y
 			-- Hence the values get moved out. Should take less time than original, so totally compatible
 			if type(time) ~= "number" then error("Delay must be a number") end
+			if time < mesecon.setting("luacontroller_minimum_interrupt", 1) then
+				error("Delay is too short (min. "..mesecon.setting("luacontroller_minimum_interrupt", 1)..")")
+			end
 			table.insert(itbl, function ()
 				-- Outside string metatable sandbox, can safely run this now
 				local luac_id = minetest.get_meta(pos):get_int("luac_id")

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -23,6 +23,7 @@ mesecon.luacontroller_string_rep_max (string:rep result length limit) int 64000 
 mesecon.luacontroller_digiline_maxlen (Digiline message size limit) int 50000 1000 1000000
 mesecon.luacontroller_maxevents (Controller execution time limit) int 10000 1000 100000
 mesecon.luacontroller_memsize (Controller memory limit) int 100000 10000 1000000
+mesecon.luacontroller_minimum_interrupt (Minimum interrupt time) fload 1 0.1 1000000
 
 # Use node timer for interrupts (runs in active blocks only).
 # IID is ignored and at most one interrupt may be queued if this setting is enabled.

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -23,7 +23,7 @@ mesecon.luacontroller_string_rep_max (string:rep result length limit) int 64000 
 mesecon.luacontroller_digiline_maxlen (Digiline message size limit) int 50000 1000 1000000
 mesecon.luacontroller_maxevents (Controller execution time limit) int 10000 1000 100000
 mesecon.luacontroller_memsize (Controller memory limit) int 100000 10000 1000000
-mesecon.luacontroller_minimum_interrupt (Minimum interrupt time) fload 1 0.1 1000000
+mesecon.luacontroller_minimum_interrupt (Minimum interrupt time) float 1 0.1 1000000
 
 # Use node timer for interrupts (runs in active blocks only).
 # IID is ignored and at most one interrupt may be queued if this setting is enabled.


### PR DESCRIPTION
I've been seeing luacontrollers being used in place of blinkies, because their signal frequency can made much faster. This change provides a reasonable default minimum interrupt time, but also provides a knob so people wishing to keep short times have the option to do so.