### PR TITLE
Handle invalid param2 in presets.lua

### DIFF
--- a/mesecons/presets.lua
+++ b/mesecons/presets.lua
@@ -64,6 +64,8 @@ local rules_buttonlike = {
 }
 
 local function rules_from_dir(ruleset, dir)
+	if not dir then return {} end
+
 	if dir.x ==  1 then return ruleset.xp end
 	if dir.y ==  1 then return ruleset.yp end
 	if dir.z ==  1 then return ruleset.zp end


### PR DESCRIPTION
Fixes https://github.com/minetest-mods/mesecons/issues/610.

To test, load up devtest with Mesecons and homedecor_lighting. Place a Mesecons lever and, separately, a `homedecor:glowlight_small_cube_14`. Use the param2 tool to set the lever's param2 to 25 and the light's param2 to 6. Try turning on the lever. Then try turning on the light using a switch adjacent to it. The game should not crash.