### PR TITLE
Fix mvps receptor_off issue

### DIFF
--- a/mesecons/init.lua
+++ b/mesecons/init.lua
@@ -99,7 +99,6 @@ mesecon.queue:add_function("receptor_off", function (pos, rules)
 		local rulenames = mesecon.rules_link_rule_all(pos, rule)
 		for _, rulename in ipairs(rulenames) do
 			mesecon.vm_begin()
-			mesecon.changesignal(np, minetest.get_node(np), rulename, mesecon.state.off, 2)
 
 			-- Turnoff returns true if turnoff process was successful, no onstate receptor
 			-- was found along the way. Commit changes that were made in voxelmanip. If turnoff

--- a/mesecons/internal.lua
+++ b/mesecons/internal.lua
@@ -542,6 +542,7 @@ function mesecon.turnoff(pos, link)
 	end
 
 	for _, sig in ipairs(signals) do
+		-- If sig.depth is 1, it has not yet been checked that the power source is actually off.
 		if sig.depth > 1 or not mesecon.is_powered(sig.pos, sig.link) then
 			mesecon.changesignal(sig.pos, sig.node, sig.link, mesecon.state.off, sig.depth)
 			if mesecon.is_effector_on(sig.node.name) and not mesecon.is_powered(sig.pos) then

--- a/mesecons/internal.lua
+++ b/mesecons/internal.lua
@@ -542,9 +542,11 @@ function mesecon.turnoff(pos, link)
 	end
 
 	for _, sig in ipairs(signals) do
-		mesecon.changesignal(sig.pos, sig.node, sig.link, mesecon.state.off, sig.depth)
-		if mesecon.is_effector_on(sig.node.name) and not mesecon.is_powered(sig.pos) then
-			mesecon.deactivate(sig.pos, sig.node, sig.link, sig.depth)
+		if sig.depth > 1 or not mesecon.is_powered(sig.pos, sig.link) then
+			mesecon.changesignal(sig.pos, sig.node, sig.link, mesecon.state.off, sig.depth)
+			if mesecon.is_effector_on(sig.node.name) and not mesecon.is_powered(sig.pos) then
+				mesecon.deactivate(sig.pos, sig.node, sig.link, sig.depth)
+			end
 		end
 	end
 

--- a/mesecons_mvps/spec/node_spec.lua
+++ b/mesecons_mvps/spec/node_spec.lua
@@ -206,7 +206,7 @@ describe("node movement", function()
 	end)
 
 	-- Since turnon is called before turnoff when pushing, effectors may be incorrectly turned off.
-	pending("does not overwrite turnon with receptor_off", function()
+	it("does not overwrite turnon with receptor_off", function()
 		local pos = {x = 0, y = 0, z = 0}
 		local dir = {x = 1, y = 0, z = 0}
 		mesecon._test_place(pos, "mesecons:test_effector")


### PR DESCRIPTION
This is a less disruptive alternative to https://github.com/minetest-mods/mesecons/pull/594. See that PR for how to reproduce the issue. This one just checks that effectors should actually be powered off when they are powered directly by a receptor. When a receptor turns off conductors instead, this check is effectively done already.

A call to `changesignal` was removed in `mesecons/init.lua`. I think this was superfluous, as it was first added in 841bc70b97e237477b0dd9ba36fd9cd307daf581 to fix a bug that does not exist in the current code.