### PR TITLE
Compile FPGA configurations to Lua

### DIFF
--- a/mesecons_fpga/init.lua
+++ b/mesecons_fpga/init.lua
@@ -330,9 +330,10 @@ plg.compile_with_cache = function(instr)
 end
 
 -- Entries are removed from the cache if they are unused for at least a minute.
+local compile_cache_max_age = mesecon.setting("fpga_cache_max_age", 1)
 local function clean_compile_cache()
 	for instr, entry in pairs(compile_cache) do
-		if entry.age < 1 then
+		if entry.age < compile_cache_max_age then
 			entry.age = entry.age + 1
 		else
 			compile_cache[instr] = nil

--- a/mesecons_fpga/logic.lua
+++ b/mesecons_fpga/logic.lua
@@ -218,7 +218,7 @@ lg.compile = function(t)
 
 	local tokens = {
 		-- Declare inputs and outputs:
-		"return function(iA, iB, iC, iD) local oA, oB, oC, oD",
+		"return function(iA, iB, iC, iD) local oA, oB, oC, oD;",
 	}
 	for i = 1, 14 do
 		local cur = t[i]
@@ -226,6 +226,7 @@ lg.compile = function(t)
 			table.insert(tokens, _dst(cur.dst))
 			table.insert(tokens, "=")
 			table.insert_all(tokens, {_action(cur.action)(_op(cur.op1), _op(cur.op2))})
+			table.insert(tokens, ";")
 		end
 	end
 	table.insert(tokens, "return oA, oB, oC, oD end")

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -17,6 +17,12 @@ mesecon.detector_radius (Player detector scanning radius) int 6 3 16
 mesecon.node_detector_distance_max (Node detector distance limit) int 10 1 16
 
 
+[mesecons_fpga]
+
+# The minimum time in minutes that unused cached FPGA configurations will be kept around.
+mesecon.fpga_cache_max_age (Compile cache max age) int 1 0 10
+
+
 [mesecons_luacontroller]
 
 mesecon.luacontroller_string_rep_max (string:rep result length limit) int 64000 1000 1000000


### PR DESCRIPTION
FPGA configurations are compiled and cached. Cache entries are removed if they are not used for at least a minute.

## Benchmark

Use this WorldEdit schematic: [fpgabenchmark.we.gz](https://github.com/minetest-mods/mesecons/files/10177181/fpgabenchmark.we.gz)

Apply this patch to Mesecons:

```patch
diff --git a/mesecons/actionqueue.lua b/mesecons/actionqueue.lua
index 72b464d..d84b6b2 100644
--- a/mesecons/actionqueue.lua
+++ b/mesecons/actionqueue.lua
@@ -64,6 +64,13 @@ function queue:add_action(pos, func, params, time, overwritecheck, priority)
 	table.insert(self.actions, action)
 end
 
+local sum = 0
+minetest.register_chatcommand("r", {
+	description = "reset",
+	params = "",
+	func = function() sum = 0 end,
+})
+
 -- execute the stored functions on a globalstep
 -- if however, the pos of a function is not loaded (get_node_or_nil == nil), do NOT execute the function
 -- this makes sure that resuming mesecons circuits when restarting minetest works fine (hm, where do we do this?)
@@ -77,6 +84,9 @@ local function globalstep_func(dtime)
 	-- queue.actions: actions to execute later
 	local actions_now = {}
 	queue.actions = {}
+	if #actions == 0 then return end
+	collectgarbage()
+	local before = minetest.get_us_time()
 
 	for _, ac in ipairs(actions) do
 		if ac.time > 0 then
@@ -110,6 +120,10 @@ local function globalstep_func(dtime)
 	for _, ac in ipairs(actions_now) do
 		queue:execute(ac)
 	end
+
+	local after = minetest.get_us_time()
+	sum = sum + (after - before)
+	minetest.log("error", sum / 1000000)
 end
 
 -- delay the time the globalsteps start to be execute by 4 seconds

```

Run the benchmark like so:

1. Turn the switch on and off 6 times to warm up.
2. Enter the command `/r` to reset the sum.
3. Turn the switch on and off 20 times.
4. Record the printed sum.

With the old Mesecons, I got a time of roughly 0.45. With the new Mesecons, the time was roughly 0.40.

## Testing

Besides the automated tests, I recommend enabling the new version of `mesecons_fpga` in Mesecons Lab and trying out some contraptions.