### PR TITLE
Pressure plates check for entity contact

### DIFF
--- a/mesecons_pressureplates/init.lua
+++ b/mesecons_pressureplates/init.lua
@@ -21,36 +21,39 @@ local function pp_on_timer(pos)
 	local function obj_touching_plate_pos(obj_ref, plate_pos)
 		local obj_pos = obj_ref:get_pos()
 		local props = obj_ref:get_properties()
-		local parent = obj_ref:get_attach()
-		if props and obj_pos and not parent then
-			local collisionbox = props.collisionbox
-			local physical = props.physical
-			local is_player = obj_ref:is_player()
-			local luaentity = obj_ref:get_luaentity()
-			local is_item = luaentity and luaentity.name == "__builtin:item"
-			if collisionbox and physical or is_player or is_item then
-				local plate_x_min = plate_pos.x - 7 / 16
-				local plate_x_max = plate_pos.x + 7 / 16
-				local plate_z_min = plate_pos.z - 7 / 16
-				local plate_z_max = plate_pos.z + 7 / 16
-				local plate_y_max = plate_pos.y - 6.5 / 16
+		if not (props and obj_pos and not obj_ref:get_attach()) then
+			return false
+		end
 
-				local obj_x_min = obj_pos.x + collisionbox[1]
-				local obj_x_max = obj_pos.x + collisionbox[4]
-				local obj_z_min = obj_pos.z + collisionbox[3]
-				local obj_z_max = obj_pos.z + collisionbox[6]
-				local obj_y_min = obj_pos.y + collisionbox[2]
+		local collisionbox = props.collisionbox
+		local physical = props.physical
+		local is_player = obj_ref:is_player()
+		local luaentity = obj_ref:get_luaentity()
+		local is_item = luaentity and luaentity.name == "__builtin:item"
+		if not (collisionbox and physical or is_player or is_item) then
+			return false
+		end
 
-				if
-					obj_y_min <= plate_y_max and
-					obj_x_min < plate_x_max and
-					obj_x_max > plate_x_min and
-					obj_z_min < plate_z_max and
-					obj_z_max > plate_z_min
-				then
-					return true
-				end
-			end
+		local plate_x_min = plate_pos.x - 7 / 16
+		local plate_x_max = plate_pos.x + 7 / 16
+		local plate_z_min = plate_pos.z - 7 / 16
+		local plate_z_max = plate_pos.z + 7 / 16
+		local plate_y_max = plate_pos.y - 6.5 / 16
+
+		local obj_x_min = obj_pos.x + collisionbox[1]
+		local obj_x_max = obj_pos.x + collisionbox[4]
+		local obj_z_min = obj_pos.z + collisionbox[3]
+		local obj_z_max = obj_pos.z + collisionbox[6]
+		local obj_y_min = obj_pos.y + collisionbox[2]
+
+		if
+			obj_y_min <= plate_y_max and
+			obj_x_min < plate_x_max and
+			obj_x_max > plate_x_min and
+			obj_z_min < plate_z_max and
+			obj_z_max > plate_z_min
+		then
+			return true
 		end
 		return false
 	end

--- a/mesecons_pressureplates/init.lua
+++ b/mesecons_pressureplates/init.lua
@@ -38,6 +38,7 @@ local function pp_on_timer(pos)
 		local plate_x_max = plate_pos.x + 7 / 16
 		local plate_z_min = plate_pos.z - 7 / 16
 		local plate_z_max = plate_pos.z + 7 / 16
+		local plate_y_min = plate_pos.y - 8 / 16
 		local plate_y_max = plate_pos.y - 6.5 / 16
 
 		local obj_x_min = obj_pos.x + collisionbox[1]
@@ -45,9 +46,11 @@ local function pp_on_timer(pos)
 		local obj_z_min = obj_pos.z + collisionbox[3]
 		local obj_z_max = obj_pos.z + collisionbox[6]
 		local obj_y_min = obj_pos.y + collisionbox[2]
+		local obj_y_max = obj_pos.y + collisionbox[5]
 
 		if
-			obj_y_min <= plate_y_max and
+			obj_y_min < plate_y_max and
+			obj_y_max > plate_y_min and
 			obj_x_min < plate_x_max and
 			obj_x_max > plate_x_min and
 			obj_z_min < plate_z_max and

--- a/mesecons_pressureplates/init.lua
+++ b/mesecons_pressureplates/init.lua
@@ -10,6 +10,49 @@ local pp_box_on = {
 	fixed = { -7/16, -8/16, -7/16, 7/16, -7.5/16, 7/16 },
 }
 
+local function obj_touching_plate_pos(obj_ref, plate_pos)
+	local obj_pos = obj_ref:get_pos()
+	local props = obj_ref:get_properties()
+	if not (props and obj_pos and not obj_ref:get_attach()) then
+		return false
+	end
+
+	local collisionbox = props.collisionbox
+	local physical = props.physical
+	local is_player = obj_ref:is_player()
+	local luaentity = obj_ref:get_luaentity()
+	local is_item = luaentity and luaentity.name == "__builtin:item"
+	if not (collisionbox and physical or is_player or is_item) then
+		return false
+	end
+
+	local plate_x_min = plate_pos.x - 7 / 16
+	local plate_x_max = plate_pos.x + 7 / 16
+	local plate_z_min = plate_pos.z - 7 / 16
+	local plate_z_max = plate_pos.z + 7 / 16
+	local plate_y_min = plate_pos.y - 8 / 16
+	local plate_y_max = plate_pos.y - 6.5 / 16
+
+	local obj_x_min = obj_pos.x + collisionbox[1]
+	local obj_x_max = obj_pos.x + collisionbox[4]
+	local obj_z_min = obj_pos.z + collisionbox[3]
+	local obj_z_max = obj_pos.z + collisionbox[6]
+	local obj_y_min = obj_pos.y + collisionbox[2]
+	local obj_y_max = obj_pos.y + collisionbox[5]
+
+	if
+		obj_y_min < plate_y_max and
+		obj_y_max > plate_y_min and
+		obj_x_min < plate_x_max and
+		obj_x_max > plate_x_min and
+		obj_z_min < plate_z_max and
+		obj_z_max > plate_z_min
+	then
+		return true
+	end
+	return false
+end
+
 local function pp_on_timer(pos)
 	local node = minetest.get_node(pos)
 	local basename = minetest.registered_nodes[node.name].pressureplate_basename
@@ -17,49 +60,6 @@ local function pp_on_timer(pos)
 	-- This is a workaround for a strange bug that occurs when the server is started
 	-- For some reason the first time on_timer is called, the pos is wrong
 	if not basename then return end
-
-	local function obj_touching_plate_pos(obj_ref, plate_pos)
-		local obj_pos = obj_ref:get_pos()
-		local props = obj_ref:get_properties()
-		if not (props and obj_pos and not obj_ref:get_attach()) then
-			return false
-		end
-
-		local collisionbox = props.collisionbox
-		local physical = props.physical
-		local is_player = obj_ref:is_player()
-		local luaentity = obj_ref:get_luaentity()
-		local is_item = luaentity and luaentity.name == "__builtin:item"
-		if not (collisionbox and physical or is_player or is_item) then
-			return false
-		end
-
-		local plate_x_min = plate_pos.x - 7 / 16
-		local plate_x_max = plate_pos.x + 7 / 16
-		local plate_z_min = plate_pos.z - 7 / 16
-		local plate_z_max = plate_pos.z + 7 / 16
-		local plate_y_min = plate_pos.y - 8 / 16
-		local plate_y_max = plate_pos.y - 6.5 / 16
-
-		local obj_x_min = obj_pos.x + collisionbox[1]
-		local obj_x_max = obj_pos.x + collisionbox[4]
-		local obj_z_min = obj_pos.z + collisionbox[3]
-		local obj_z_max = obj_pos.z + collisionbox[6]
-		local obj_y_min = obj_pos.y + collisionbox[2]
-		local obj_y_max = obj_pos.y + collisionbox[5]
-
-		if
-			obj_y_min < plate_y_max and
-			obj_y_max > plate_y_min and
-			obj_x_min < plate_x_max and
-			obj_x_max > plate_x_min and
-			obj_z_min < plate_z_max and
-			obj_z_max > plate_z_min
-		then
-			return true
-		end
-		return false
-	end
 
 	local objs = minetest.get_objects_inside_radius(pos, 1)
 	local obj_touching = false


### PR DESCRIPTION
This PR makes pressure plates check to see if the collisionbox of an entity intersects with the pressure plate. I originally put this in MineClone2.

Without the PR an entity did not need to contact the pressure plate to trigger it. Also some entities associated with nodes would trigger it if the node is next to the pressure plate.

![cannon](https://user-images.githubusercontent.com/16406771/213800532-44293ea9-96a3-4e75-bb58-18b08c68d0d0.PNG)
![flying](https://user-images.githubusercontent.com/16406771/213800551-15014180-177b-43d9-94fc-9d7777d6ebf1.png)


One possible issue is that large entites or entites with the origin point not in the feet can't be detected. This can be simply fixed by increasing the radius passed to minetest.get_objects_inside_radius().

Players, mobs, dropped items, etcetera are supported. Those were all supported before but I just want to establish the facts.

I tested in MT 5.0.1 and MT 5.6.