### PR TITLE
add option to disable printing inside a luacontroller

### DIFF
--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -203,11 +203,13 @@ end
 -------------------------
 
 local function safe_print(param)
-	local string_meta = getmetatable("")
-	local sandbox = string_meta.__index
-	string_meta.__index = string -- Leave string sandbox temporarily
-	print(dump(param))
-	string_meta.__index = sandbox -- Restore string sandbox
+	if mesecon.setting("luacontroller_print_behavior", "log") == "log" then
+		local string_meta = getmetatable("")
+		local sandbox = string_meta.__index
+		string_meta.__index = string -- Leave string sandbox temporarily
+		minetest.log("action", string.format("[mesecons_luacontroller] print(%s)", dump(param)))
+		string_meta.__index = sandbox -- Restore string sandbox
+	end
 end
 
 local function safe_date()

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -28,7 +28,7 @@ mesecon.luacontroller_memsize (Controller memory limit) int 100000 10000 1000000
 # IID is ignored and at most one interrupt may be queued if this setting is enabled.
 mesecon.luacontroller_lightweight_interrupts (Lightweight interrupts) bool false
 
-# Behavior of "print" inside a luacontroller. By default, this emits a message into debug.txt.
+# Behavior of print() inside a luacontroller. By default, this emits a message into actionstream.
 # Set it to noop if you wish to disable that behavior.
 mesecon.luacontroller_print_behavior (Behavior of print) enum log log,noop
 

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -28,9 +28,9 @@ mesecon.luacontroller_memsize (Controller memory limit) int 100000 10000 1000000
 # IID is ignored and at most one interrupt may be queued if this setting is enabled.
 mesecon.luacontroller_lightweight_interrupts (Lightweight interrupts) bool false
 
-# behavior of "print" inside a luacontroller. by default, this emits a message into debug.txt.
-# set it to noop if you wish to disable that behavior.
-mesecon.luacontroller_print_behavior (behavior of print) enum log log,noop
+# Behavior of "print" inside a luacontroller. By default, this emits a message into debug.txt.
+# Set it to noop if you wish to disable that behavior.
+mesecon.luacontroller_print_behavior (Behavior of print) enum log log,noop
 
 [mesecons_mvps]
 

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -28,6 +28,10 @@ mesecon.luacontroller_memsize (Controller memory limit) int 100000 10000 1000000
 # IID is ignored and at most one interrupt may be queued if this setting is enabled.
 mesecon.luacontroller_lightweight_interrupts (Lightweight interrupts) bool false
 
+# behavior of "print" inside a luacontroller. by default, this emits a message into debug.txt.
+# set it to noop if you wish to disable that behavior.
+mesecon.luacontroller_print_behavior (behavior of print) enum log log,noop
+
 [mesecons_mvps]
 
 # In pre-existing world, MVPS may not be labelled with the owner.


### PR DESCRIPTION
fixes #626.

default behavior is now to dump and log the argument to print similar to how it used to work. by setting `mesecon.luacontroller_print_behavior = noop` in minetest.conf, this behavior can be disabled. 