### PR TITLE
Sticky block: add crafting recipe

### DIFF
--- a/mesecons_stickyblocks/init.lua
+++ b/mesecons_stickyblocks/init.lua
@@ -19,3 +19,15 @@ minetest.register_node("mesecons_stickyblocks:sticky_block_all", {
 	end,
 	sounds = mesecon.node_sound.wood,
 })
+
+local wood = "group:wood"
+local glue = "mesecons_materials:glue"
+
+minetest.register_craft({
+	output = "mesecons_stickyblocks:sticky_block_all",
+	recipe = {
+		{glue, glue, glue},
+		{glue, wood, glue},
+		{glue, glue, glue},
+	}
+})


### PR DESCRIPTION
Closes #218. But likely shouldn’t be merged until fixing #645.
The recipe was suggested by @Wuzzy2 in https://github.com/minetest-mods/mesecons/issues/218#issuecomment-356408162.