### PR TITLE
fix issue 645: prevent pistons from pushing blocks into their current position, deleting them.

### DIFF
--- a/mesecons_pistons/init.lua
+++ b/mesecons_pistons/init.lua
@@ -84,7 +84,16 @@ local piston_on = function(pos, node)
 	local pistonspec = get_pistonspec(node.name, "offname")
 	local dir = vector.multiply(minetest.facedir_to_dir(node.param2), -1)
 	local pusher_pos = vector.add(pos, dir)
+	local behind_pos = vector.subtract(pos, dir)
 	local meta = minetest.get_meta(pos)
+	-- NOTE: this gets calculated twice, but fixing this would mean changing the public api.
+	local stack = mesecon.mvps_get_stack(pusher_pos, dir, max_push, meta:get_string("owner"))
+	for _, n in ipairs(stack) do
+		-- fix issue 645
+		if vector.equals(n.pos, behind_pos) then
+			return
+		end
+	end
 	local success, stack, oldstack = mesecon.mvps_push(pusher_pos, dir, max_push, meta:get_string("owner"))
 	if not success then
 		if stack == "protected" then


### PR DESCRIPTION
this isn't the most efficient fix, but as far as i can tell, anything better would require changing the public api, and i don't want to break any other mods that may depend on mesecons_mvps.

some things i noticed while fixing this bug:
* when pushing a sticky block, the piston pushing the block actually gets dragged along behind it.  the only reason this isn't visible is because a piston extension places two nodes. 
* an immovable node behind a sticky block will prevent that block from being moved forward.