### PR TITLE
optimize mvps_push_or_pull

### DIFF
--- a/mesecons/fifo_queue.lua
+++ b/mesecons/fifo_queue.lua
@@ -20,6 +20,11 @@ function fifo_queue.add(self, v)
 	self.buf_in[n] = v
 end
 
+-- add several elements to the queue
+function fifo_queue.add_list(self, v)
+	table.move(v, 1, #v, self.n_in + 1, self.buf_in)
+	self.n_in = self.n_in + #v
+end
 -- removes and returns the next element, or nil of empty
 function fifo_queue.take(self)
 	local i_out = self.i_out

--- a/mesecons/fifo_queue.lua
+++ b/mesecons/fifo_queue.lua
@@ -20,10 +20,19 @@ function fifo_queue.add(self, v)
 	self.buf_in[n] = v
 end
 
--- add several elements to the queue
-function fifo_queue.add_list(self, v)
-	table.move(v, 1, #v, self.n_in + 1, self.buf_in)
-	self.n_in = self.n_in + #v
+-- table.move is not available in some lua versions, provide a fallback implementaion
+if table.move ~= nil then
+	-- add several elements to the queue
+	function fifo_queue.add_list(self, v)
+		table.move(v, 1, #v, self.n_in + 1, self.buf_in)
+		self.n_in = self.n_in + #v
+	end
+else
+	function fifo_queue.add_list(self, v)
+		for _, elem in ipairs(v) do
+			self:add(elem)
+		end
+	end
 end
 -- removes and returns the next element, or nil of empty
 function fifo_queue.take(self)

--- a/mesecons_mvps/init.lua
+++ b/mesecons_mvps/init.lua
@@ -70,8 +70,8 @@ function mesecon.mvps_get_stack(pos, dir, maximum, all_pull_sticky)
 	local nodes = {}
 	local pos_set = {}
 	local frontiers = mesecon.fifo_queue.new()
-	--local vector_equals = vector.equals
 	frontiers:add(vector.new(pos))
+	-- micro-optimization: lift local definitions out of loop
 	local nodedef
 	local np_hash
 	local nn
@@ -100,7 +100,7 @@ function mesecon.mvps_get_stack(pos, dir, maximum, all_pull_sticky)
 			-- If adjacent node is sticky block and connects add that
 			-- position
 			for _, r in ipairs(mesecon.rules.alldirs) do
-				local adjpos = vector.add(np, r)
+				adjpos = vector.add(np, r)
 				-- optimization: don't check blocks that are already part of the stack
 				if not pos_set[minetest.hash_node_position(adjpos)] then
 					adjnode = minetest.get_node(adjpos)

--- a/mesecons_mvps/init.lua
+++ b/mesecons_mvps/init.lua
@@ -95,16 +95,19 @@ function mesecon.mvps_get_stack(pos, dir, maximum, all_pull_sticky)
 			-- position
 			for _, r in ipairs(mesecon.rules.alldirs) do
 				local adjpos = vector.add(np, r)
-				local adjnode = minetest.get_node(adjpos)
-				if minetest.registered_nodes[adjnode.name]
-				and minetest.registered_nodes[adjnode.name].mvps_sticky then
-					local sticksto = minetest.registered_nodes[adjnode.name]
-						.mvps_sticky(adjpos, adjnode)
-
-					-- connects to this position?
-					for _, link in ipairs(sticksto) do
-						if vector.equals(link, np) then
-							frontiers:add(adjpos)
+				-- optimization: don't check blocks that are already part of the stack
+				if not pos_set[minetest.hash_node_position(adjpos)] then
+					local adjnode = minetest.get_node(adjpos)
+					if minetest.registered_nodes[adjnode.name]
+					and minetest.registered_nodes[adjnode.name].mvps_sticky then
+						local sticksto = minetest.registered_nodes[adjnode.name]
+							.mvps_sticky(adjpos, adjnode)
+	
+						-- connects to this position?
+						for _, link in ipairs(sticksto) do
+							if vector.equals(link, np) then
+								frontiers:add(adjpos)
+							end
 						end
 					end
 				end

--- a/mesecons_mvps/init.lua
+++ b/mesecons_mvps/init.lua
@@ -85,9 +85,10 @@ function mesecon.mvps_get_stack(pos, dir, maximum, all_pull_sticky)
 			if minetest.registered_nodes[nn.name]
 			and minetest.registered_nodes[nn.name].mvps_sticky then
 				local connected = minetest.registered_nodes[nn.name].mvps_sticky(np, nn)
-				for _, cp in ipairs(connected) do
+				frontiers:add_list(connected)
+				--[[for _, cp in ipairs(connected) do
 					frontiers:add(cp)
-				end
+				end]]
 			end
 
 			frontiers:add(vector.add(np, dir))

--- a/mesecons_mvps/init.lua
+++ b/mesecons_mvps/init.lua
@@ -71,27 +71,19 @@ function mesecon.mvps_get_stack(pos, dir, maximum, all_pull_sticky)
 	local pos_set = {}
 	local frontiers = mesecon.fifo_queue.new()
 	frontiers:add(vector.new(pos))
-	-- micro-optimization: lift local definitions out of loop
-	local nodedef
-	local np_hash
-	local nn
-	local connected
-	local adjnode
-	local adjdef
-	local sticksto
 
 	for np in frontiers:iter() do
-		np_hash = minetest.hash_node_position(np)
-		nn = not pos_set[np_hash] and minetest.get_node(np)
+		local np_hash = minetest.hash_node_position(np)
+		local nn = not pos_set[np_hash] and minetest.get_node(np)
 		if nn and not node_replaceable(nn.name) then
 			pos_set[np_hash] = true
 			table.insert(nodes, {node = nn, pos = np})
 			if #nodes > maximum then return nil end
 
 			-- add connected nodes to frontiers
-			nodedef = minetest.registered_nodes[nn.name]
+			local nodedef = minetest.registered_nodes[nn.name]
 			if nodedef and nodedef.mvps_sticky then
-				connected = nodedef.mvps_sticky(np, nn)
+				local connected = nodedef.mvps_sticky(np, nn)
 				frontiers:add_list(connected)
 			end
 
@@ -100,13 +92,13 @@ function mesecon.mvps_get_stack(pos, dir, maximum, all_pull_sticky)
 			-- If adjacent node is sticky block and connects add that
 			-- position
 			for _, r in ipairs(mesecon.rules.alldirs) do
-				adjpos = vector.add(np, r)
+				local adjpos = vector.add(np, r)
 				-- optimization: don't check blocks that are already part of the stack
 				if not pos_set[minetest.hash_node_position(adjpos)] then
-					adjnode = minetest.get_node(adjpos)
-					adjdef = minetest.registered_nodes[adjnode.name]
+					local adjnode = minetest.get_node(adjpos)
+					local adjdef = minetest.registered_nodes[adjnode.name]
 					if adjdef and adjdef.mvps_sticky then
-						sticksto = adjdef.mvps_sticky(adjpos, adjnode)
+						local sticksto = adjdef.mvps_sticky(adjpos, adjnode)
 	
 						-- connects to this position?
 						for _, link in ipairs(sticksto) do

--- a/mesecons_mvps/init.lua
+++ b/mesecons_mvps/init.lua
@@ -70,21 +70,28 @@ function mesecon.mvps_get_stack(pos, dir, maximum, all_pull_sticky)
 	local nodes = {}
 	local pos_set = {}
 	local frontiers = mesecon.fifo_queue.new()
-	local vector_equals = vector.equals
+	--local vector_equals = vector.equals
 	frontiers:add(vector.new(pos))
+	local nodedef
+	local np_hash
+	local nn
+	local connected
+	local adjnode
+	local adjdef
+	local sticksto
 
 	for np in frontiers:iter() do
-		local np_hash = minetest.hash_node_position(np)
-		local nn = not pos_set[np_hash] and minetest.get_node(np)
+		np_hash = minetest.hash_node_position(np)
+		nn = not pos_set[np_hash] and minetest.get_node(np)
 		if nn and not node_replaceable(nn.name) then
 			pos_set[np_hash] = true
 			table.insert(nodes, {node = nn, pos = np})
 			if #nodes > maximum then return nil end
 
 			-- add connected nodes to frontiers
-			local nodedef = minetest.registered_nodes[nn.name]
+			nodedef = minetest.registered_nodes[nn.name]
 			if nodedef and nodedef.mvps_sticky then
-				local connected = nodedef.mvps_sticky(np, nn)
+				connected = nodedef.mvps_sticky(np, nn)
 				frontiers:add_list(connected)
 			end
 
@@ -96,14 +103,14 @@ function mesecon.mvps_get_stack(pos, dir, maximum, all_pull_sticky)
 				local adjpos = vector.add(np, r)
 				-- optimization: don't check blocks that are already part of the stack
 				if not pos_set[minetest.hash_node_position(adjpos)] then
-					local adjnode = minetest.get_node(adjpos)
-					local adjdef = minetest.registered_nodes[adjnode.name]
+					adjnode = minetest.get_node(adjpos)
+					adjdef = minetest.registered_nodes[adjnode.name]
 					if adjdef and adjdef.mvps_sticky then
-						local sticksto = adjdef.mvps_sticky(adjpos, adjnode)
+						sticksto = adjdef.mvps_sticky(adjpos, adjnode)
 	
 						-- connects to this position?
 						for _, link in ipairs(sticksto) do
-							if vector_equals(link, np) then
+							if vector.equals(link, np) then
 								frontiers:add(adjpos)
 								break
 							end
@@ -273,11 +280,11 @@ function mesecon.mvps_push_or_pull(pos, stackdir, movedir, maximum, all_pull_sti
 	
 
 	on_mvps_move(moved_nodes)	
-	minetest.debug("get_stack time", time_get_stack - time_start)
+	--[[minetest.debug("get_stack time", time_get_stack - time_start)
 	minetest.debug("remove_nodes time", time_remove_nodes_end - time_remove_nodes_start)
 	minetest.debug("set_nodes time", time_set_nodes_end - time_set_nodes_start)
 	minetest.debug("moved_nodes time", time_moved_nodes_end - time_moved_nodes_start)
-	minetest.debug("full time", minetest.get_us_time() - time_start)
+	minetest.debug("full time", minetest.get_us_time() - time_start)]]
 	return true, nodes, oldstack
 end
 

--- a/mesecons_mvps/init.lua
+++ b/mesecons_mvps/init.lua
@@ -98,15 +98,16 @@ function mesecon.mvps_get_stack(pos, dir, maximum, all_pull_sticky)
 				-- optimization: don't check blocks that are already part of the stack
 				if not pos_set[minetest.hash_node_position(adjpos)] then
 					local adjnode = minetest.get_node(adjpos)
-					if minetest.registered_nodes[adjnode.name]
-					and minetest.registered_nodes[adjnode.name].mvps_sticky then
-						local sticksto = minetest.registered_nodes[adjnode.name]
-							.mvps_sticky(adjpos, adjnode)
+					local adjdef = minetest.registered_nodes[adjnode.name]
+					if adjdef
+					and adjdef.mvps_sticky then
+						local sticksto = adjdef.mvps_sticky(adjpos, adjnode)
 	
 						-- connects to this position?
 						for _, link in ipairs(sticksto) do
 							if vector.equals(link, np) then
 								frontiers:add(adjpos)
+								break
 							end
 						end
 					end

--- a/mesecons_mvps/init.lua
+++ b/mesecons_mvps/init.lua
@@ -82,13 +82,10 @@ function mesecon.mvps_get_stack(pos, dir, maximum, all_pull_sticky)
 			if #nodes > maximum then return nil end
 
 			-- add connected nodes to frontiers
-			if minetest.registered_nodes[nn.name]
-			and minetest.registered_nodes[nn.name].mvps_sticky then
-				local connected = minetest.registered_nodes[nn.name].mvps_sticky(np, nn)
+			local nodedef = minetest.registered_nodes[nn.name]
+			if nodedef and nodedef.mvps_sticky then
+				local connected = nodedef.mvps_sticky(np, nn)
 				frontiers:add_list(connected)
-				--[[for _, cp in ipairs(connected) do
-					frontiers:add(cp)
-				end]]
 			end
 
 			frontiers:add(vector.add(np, dir))
@@ -101,8 +98,7 @@ function mesecon.mvps_get_stack(pos, dir, maximum, all_pull_sticky)
 				if not pos_set[minetest.hash_node_position(adjpos)] then
 					local adjnode = minetest.get_node(adjpos)
 					local adjdef = minetest.registered_nodes[adjnode.name]
-					if adjdef
-					and adjdef.mvps_sticky then
+					if adjdef and adjdef.mvps_sticky then
 						local sticksto = adjdef.mvps_sticky(adjpos, adjnode)
 	
 						-- connects to this position?

--- a/mesecons_mvps/init.lua
+++ b/mesecons_mvps/init.lua
@@ -204,13 +204,10 @@ end
 --  - empty string means legacy MVPS, actual check depends on configuration
 --  - "$unknown" is a sentinel for forcing the check
 function mesecon.mvps_push_or_pull(pos, stackdir, movedir, maximum, all_pull_sticky, player_name)
-	local time_start = minetest.get_us_time()
 	local nodes = mesecon.mvps_get_stack(pos, movedir, maximum, all_pull_sticky)
-	local time_get_stack = minetest.get_us_time()
 
 	if not nodes then return end
 
-	local time_protection_check_start = minetest.get_us_time()
 	local protection_check_set = {}
 	if vector.equals(stackdir, movedir) then -- pushing
 		add_pos(protection_check_set, pos)
@@ -226,9 +223,7 @@ function mesecon.mvps_push_or_pull(pos, stackdir, movedir, maximum, all_pull_sti
 	if are_protected(protection_check_set, player_name) then
 		return false, "protected"
 	end
-	local time_protection_check_end = minetest.get_us_time()
 
-	local time_remove_nodes_start = minetest.get_us_time()
 	-- remove all nodes
 	for _, n in ipairs(nodes) do
 		n.meta = minetest.get_meta(n.pos):to_table()
@@ -238,7 +233,6 @@ function mesecon.mvps_push_or_pull(pos, stackdir, movedir, maximum, all_pull_sti
 		end
 		minetest.remove_node(n.pos)
 	end
-	local time_remove_nodes_end = minetest.get_us_time()
 	local oldstack = mesecon.tablecopy(nodes)
 
 	-- update mesecons for removed nodes ( has to be done after all nodes have been removed )
@@ -246,7 +240,6 @@ function mesecon.mvps_push_or_pull(pos, stackdir, movedir, maximum, all_pull_sti
 		mesecon.on_dignode(n.pos, n.node)
 	end
 
-	local time_set_nodes_start = minetest.get_us_time()
 	-- add nodes
 	for _, n in ipairs(nodes) do
 		local np = vector.add(n.pos, movedir)
@@ -263,9 +256,7 @@ function mesecon.mvps_push_or_pull(pos, stackdir, movedir, maximum, all_pull_sti
 			minetest.get_node_timer(np):set(unpack(n.node_timer))
 		end
 	end
-	local time_set_nodes_end = minetest.get_us_time()
 
-	local time_moved_nodes_start = minetest.get_us_time()
 	local moved_nodes = {}
 	for i in ipairs(nodes) do
 		moved_nodes[i] = {}
@@ -276,15 +267,9 @@ function mesecon.mvps_push_or_pull(pos, stackdir, movedir, maximum, all_pull_sti
 		moved_nodes[i].meta = nodes[i].meta
 		moved_nodes[i].node_timer = nodes[i].node_timer
 	end
-	local time_moved_nodes_end = minetest.get_us_time()
 	
 
 	on_mvps_move(moved_nodes)	
-	--[[minetest.debug("get_stack time", time_get_stack - time_start)
-	minetest.debug("remove_nodes time", time_remove_nodes_end - time_remove_nodes_start)
-	minetest.debug("set_nodes time", time_set_nodes_end - time_set_nodes_start)
-	minetest.debug("moved_nodes time", time_moved_nodes_end - time_moved_nodes_start)
-	minetest.debug("full time", minetest.get_us_time() - time_start)]]
 	return true, nodes, oldstack
 end
 

--- a/mesecons_mvps/init.lua
+++ b/mesecons_mvps/init.lua
@@ -70,6 +70,7 @@ function mesecon.mvps_get_stack(pos, dir, maximum, all_pull_sticky)
 	local nodes = {}
 	local pos_set = {}
 	local frontiers = mesecon.fifo_queue.new()
+	local vector_equals = vector.equals
 	frontiers:add(vector.new(pos))
 
 	for np in frontiers:iter() do
@@ -105,7 +106,7 @@ function mesecon.mvps_get_stack(pos, dir, maximum, all_pull_sticky)
 	
 						-- connects to this position?
 						for _, link in ipairs(sticksto) do
-							if vector.equals(link, np) then
+							if vector_equals(link, np) then
 								frontiers:add(adjpos)
 								break
 							end

--- a/mesecons_mvps/init.lua
+++ b/mesecons_mvps/init.lua
@@ -195,10 +195,13 @@ end
 --  - empty string means legacy MVPS, actual check depends on configuration
 --  - "$unknown" is a sentinel for forcing the check
 function mesecon.mvps_push_or_pull(pos, stackdir, movedir, maximum, all_pull_sticky, player_name)
+	local time_start = minetest.get_us_time()
 	local nodes = mesecon.mvps_get_stack(pos, movedir, maximum, all_pull_sticky)
+	local time_get_stack = minetest.get_us_time()
 
 	if not nodes then return end
 
+	local time_protection_check_start = minetest.get_us_time()
 	local protection_check_set = {}
 	if vector.equals(stackdir, movedir) then -- pushing
 		add_pos(protection_check_set, pos)
@@ -214,7 +217,9 @@ function mesecon.mvps_push_or_pull(pos, stackdir, movedir, maximum, all_pull_sti
 	if are_protected(protection_check_set, player_name) then
 		return false, "protected"
 	end
+	local time_protection_check_end = minetest.get_us_time()
 
+	local time_remove_nodes_start = minetest.get_us_time()
 	-- remove all nodes
 	for _, n in ipairs(nodes) do
 		n.meta = minetest.get_meta(n.pos):to_table()
@@ -224,7 +229,7 @@ function mesecon.mvps_push_or_pull(pos, stackdir, movedir, maximum, all_pull_sti
 		end
 		minetest.remove_node(n.pos)
 	end
-
+	local time_remove_nodes_end = minetest.get_us_time()
 	local oldstack = mesecon.tablecopy(nodes)
 
 	-- update mesecons for removed nodes ( has to be done after all nodes have been removed )
@@ -232,6 +237,7 @@ function mesecon.mvps_push_or_pull(pos, stackdir, movedir, maximum, all_pull_sti
 		mesecon.on_dignode(n.pos, n.node)
 	end
 
+	local time_set_nodes_start = minetest.get_us_time()
 	-- add nodes
 	for _, n in ipairs(nodes) do
 		local np = vector.add(n.pos, movedir)
@@ -248,7 +254,9 @@ function mesecon.mvps_push_or_pull(pos, stackdir, movedir, maximum, all_pull_sti
 			minetest.get_node_timer(np):set(unpack(n.node_timer))
 		end
 	end
+	local time_set_nodes_end = minetest.get_us_time()
 
+	local time_moved_nodes_start = minetest.get_us_time()
 	local moved_nodes = {}
 	for i in ipairs(nodes) do
 		moved_nodes[i] = {}
@@ -259,9 +267,15 @@ function mesecon.mvps_push_or_pull(pos, stackdir, movedir, maximum, all_pull_sti
 		moved_nodes[i].meta = nodes[i].meta
 		moved_nodes[i].node_timer = nodes[i].node_timer
 	end
+	local time_moved_nodes_end = minetest.get_us_time()
+	
 
-	on_mvps_move(moved_nodes)
-
+	on_mvps_move(moved_nodes)	
+	minetest.debug("get_stack time", time_get_stack - time_start)
+	minetest.debug("remove_nodes time", time_remove_nodes_end - time_remove_nodes_start)
+	minetest.debug("set_nodes time", time_set_nodes_end - time_set_nodes_start)
+	minetest.debug("moved_nodes time", time_moved_nodes_end - time_moved_nodes_start)
+	minetest.debug("full time", minetest.get_us_time() - time_start)
 	return true, nodes, oldstack
 end
 


### PR DESCRIPTION
this function is a big bottleneck, since it contains several layers of nested loops, and has quite a few allocations in the innermost levels.

i did my best to optimize it, and i'm only confident in about half my changes, although some imprecice testing implied as much as a 10x speedup.

if someone could benchmark this properly and see what changes are worth it, that would be greatly appreciated.