### PR TITLE
fix 1-tick pulses causing delayers to get stuck in the on state

### DIFF
--- a/mesecons_delayer/init.lua
+++ b/mesecons_delayer/init.lua
@@ -62,6 +62,8 @@ local def = {
 	sounds = mesecon.node_sound.stone,
 	on_blast = mesecon.on_blastnode,
 	drop = "mesecons_delayer:delayer_off_1",
+	delayer_onstate = "mesecons_delayer:delayer_on_"..tostring(i),
+	delayer_offstate = "mesecons_delayer:delayer_off_"..tostring(i),
 }
 
 -- Deactivated delayer definition defaults
@@ -93,7 +95,6 @@ local off_state = {
 			param2 = node.param2
 		})
 	end,
-	delayer_onstate = "mesecons_delayer:delayer_on_"..tostring(i),
 	mesecons = {
 		receptor =
 		{
@@ -135,7 +136,6 @@ local on_state = {
 			param2 = node.param2
 		})
 	end,
-	delayer_offstate = "mesecons_delayer:delayer_off_"..tostring(i),
 	mesecons = {
 		receptor =
 		{

--- a/mesecons_delayer/init.lua
+++ b/mesecons_delayer/init.lua
@@ -103,6 +103,7 @@ local off_state = {
 		effector =
 		{
 			rules = delayer_get_input_rules,
+			action_off = delayer_deactivate,
 			action_on = delayer_activate
 		}
 	},
@@ -144,7 +145,8 @@ local on_state = {
 		effector =
 		{
 			rules = delayer_get_input_rules,
-			action_off = delayer_deactivate
+			action_off = delayer_deactivate,
+			action_on = delayer_activate
 		}
 	},
 }


### PR DESCRIPTION
Fixes #656

i believe the cause of this bug is a chain of events as such:
* delayer receives effector_on, and starts a timer
* delayer receives effector_off, however the node has not been updated somehow (perhaps due to caching somewhere), and thus this is dropped
* delayer swaps node into on state

 this may be caused by an underlying bug somewhere in the action queue, but simply changing the unpowered state so it also responds to power off events seems to do the trick just fine.