### PR TITLE
Reduce redundancy in minetest.registered_nodes lookups

### DIFF
--- a/mesecons/internal.lua
+++ b/mesecons/internal.lua
@@ -51,27 +51,18 @@ mesecon.fifo_queue = dofile(minetest.get_modpath("mesecons").."/fifo_queue.lua")
 
 -- General
 function mesecon.get_effector(nodename)
-	if  minetest.registered_nodes[nodename]
-	and minetest.registered_nodes[nodename].mesecons
-	and minetest.registered_nodes[nodename].mesecons.effector then
-		return minetest.registered_nodes[nodename].mesecons.effector
-	end
+	local def = minetest.registered_nodes[nodename]
+	return def and def.mesecons and def.mesecons.effector
 end
 
 function mesecon.get_receptor(nodename)
-	if  minetest.registered_nodes[nodename]
-	and minetest.registered_nodes[nodename].mesecons
-	and minetest.registered_nodes[nodename].mesecons.receptor then
-		return minetest.registered_nodes[nodename].mesecons.receptor
-	end
+	local def = minetest.registered_nodes[nodename]
+	return def and def.mesecons and def.mesecons.receptor
 end
 
 function mesecon.get_conductor(nodename)
-	if  minetest.registered_nodes[nodename]
-	and minetest.registered_nodes[nodename].mesecons
-	and minetest.registered_nodes[nodename].mesecons.conductor then
-		return minetest.registered_nodes[nodename].mesecons.conductor
-	end
+	local def = minetest.registered_nodes[nodename]
+	return def and def.mesecons and def.mesecons.conductor
 end
 
 function mesecon.get_any_outputrules(node)

--- a/mesecons_extrawires/vertical.lua
+++ b/mesecons_extrawires/vertical.lua
@@ -40,35 +40,39 @@ local bottom_rules = {
 	{x=0, y=2, z=0} -- receive power from pressure plate / detector / ... 2 nodes above
 }
 
+local function is_vertical_conductor(nodename)
+	local def = minetest.registered_nodes[nodename]
+	return def and def.is_vertical_conductor
+end
+
 local vertical_updatepos = function (pos)
 	local node = minetest.get_node(pos)
-	if minetest.registered_nodes[node.name]
-	and minetest.registered_nodes[node.name].is_vertical_conductor then
-		local node_above = minetest.get_node(vector.add(pos, vertical_rules[1]))
-		local node_below = minetest.get_node(vector.add(pos, vertical_rules[2]))
-
-		local above = minetest.registered_nodes[node_above.name]
-			and minetest.registered_nodes[node_above.name].is_vertical_conductor
-		local below = minetest.registered_nodes[node_below.name]
-			and minetest.registered_nodes[node_below.name].is_vertical_conductor
-
-		mesecon.on_dignode(pos, node)
-
-		-- Always place offstate conductor and let mesecon.on_placenode take care
-		local newname = "mesecons_extrawires:vertical_"
-		if above and below then -- above and below: vertical mesecon
-			newname = newname .. "off"
-		elseif above and not below then -- above only: bottom
-			newname = newname .. "bottom_off"
-		elseif not above and below then -- below only: top
-			newname = newname .. "top_off"
-		else -- no vertical wire above, no vertical wire below: use bottom
-			newname = newname .. "bottom_off"
-		end
-
-		minetest.set_node(pos, {name = newname})
-		mesecon.on_placenode(pos, {name = newname})
+	if not is_vertical_conductor(node.name) then
+		return
 	end
+
+	local node_above = minetest.get_node(vector.add(pos, vertical_rules[1]))
+	local node_below = minetest.get_node(vector.add(pos, vertical_rules[2]))
+
+	local above = is_vertical_conductor(node_above.name)
+	local below = is_vertical_conductor(node_below.name)
+
+	mesecon.on_dignode(pos, node)
+
+	-- Always place offstate conductor and let mesecon.on_placenode take care
+	local newname = "mesecons_extrawires:vertical_"
+	if above and below then -- above and below: vertical mesecon
+		newname = newname .. "off"
+	elseif above and not below then -- above only: bottom
+		newname = newname .. "bottom_off"
+	elseif not above and below then -- below only: top
+		newname = newname .. "top_off"
+	else -- no vertical wire above, no vertical wire below: use bottom
+		newname = newname .. "bottom_off"
+	end
+
+	minetest.set_node(pos, {name = newname})
+	mesecon.on_placenode(pos, {name = newname})
 end
 
 local vertical_update = function (pos)

--- a/mesecons_mvps/init.lua
+++ b/mesecons_mvps/init.lua
@@ -81,9 +81,9 @@ function mesecon.mvps_get_stack(pos, dir, maximum, all_pull_sticky)
 			if #nodes > maximum then return nil end
 
 			-- add connected nodes to frontiers
-			if minetest.registered_nodes[nn.name]
-			and minetest.registered_nodes[nn.name].mvps_sticky then
-				local connected = minetest.registered_nodes[nn.name].mvps_sticky(np, nn)
+			local nndef = minetest.registered_nodes[nn.name]
+			if nndef and nndef.mvps_sticky then
+				local connected = nndef.mvps_sticky(np, nn)
 				for _, cp in ipairs(connected) do
 					frontiers:add(cp)
 				end
@@ -96,10 +96,9 @@ function mesecon.mvps_get_stack(pos, dir, maximum, all_pull_sticky)
 			for _, r in ipairs(mesecon.rules.alldirs) do
 				local adjpos = vector.add(np, r)
 				local adjnode = minetest.get_node(adjpos)
-				if minetest.registered_nodes[adjnode.name]
-				and minetest.registered_nodes[adjnode.name].mvps_sticky then
-					local sticksto = minetest.registered_nodes[adjnode.name]
-						.mvps_sticky(adjpos, adjnode)
+				local adjdef = minetest.registered_nodes[adjnode.name]
+				if adjdef and adjdef.mvps_sticky then
+					local sticksto = adjdef.mvps_sticky(adjpos, adjnode)
 
 					-- connects to this position?
 					for _, link in ipairs(sticksto) do

--- a/mesecons_wires/init.lua
+++ b/mesecons_wires/init.lua
@@ -13,11 +13,11 @@ local S = minetest.get_translator(minetest.get_current_modname())
 -- self_pos = pos of any mesecon node, from_pos = pos of conductor to getconnect for
 local wire_getconnect = function (from_pos, self_pos)
 	local node = minetest.get_node(self_pos)
-	if minetest.registered_nodes[node.name]
-	and minetest.registered_nodes[node.name].mesecons then
+	local def = minetest.registered_nodes[node.name]
+	if def and def.mesecons then
 		-- rules of node to possibly connect to
 		local rules
-		if (minetest.registered_nodes[node.name].mesecon_wire) then
+		if def.mesecon_wire then
 			rules = mesecon.rules.default
 		else
 			rules = mesecon.get_any_rules(node)
@@ -68,16 +68,18 @@ end
 
 local update_on_place_dig = function (pos, node)
 	-- Update placed node (get_node again as it may have been dug)
-	local nn = minetest.get_node(pos)
-	if (minetest.registered_nodes[nn.name])
-	and (minetest.registered_nodes[nn.name].mesecon_wire) then
-		wire_updateconnect(pos)
+	do
+		local nn = minetest.get_node(pos)
+		local def = minetest.registered_nodes[nn.name]
+		if def and def.mesecon_wire then
+			wire_updateconnect(pos)
+		end
 	end
 
 	-- Update nodes around it
 	local rules
-	if minetest.registered_nodes[node.name]
-	and minetest.registered_nodes[node.name].mesecon_wire then
+	local ndef = minetest.registered_nodes[node.name]
+	if ndef and ndef.mesecon_wire then
 		rules = mesecon.rules.default
 	else
 		rules = mesecon.get_any_rules(node)
@@ -86,8 +88,8 @@ local update_on_place_dig = function (pos, node)
 
 	for _, r in ipairs(mesecon.flattenrules(rules)) do
 		local np = vector.add(pos, r)
-		if minetest.registered_nodes[minetest.get_node(np).name]
-		and minetest.registered_nodes[minetest.get_node(np).name].mesecon_wire then
+		local rdef = minetest.registered_nodes[minetest.get_node(np).name]
+		if rdef and rdef.mesecon_wire then
 			wire_updateconnect(np)
 		end
 	end


### PR DESCRIPTION
Less spectacular deduplication. Depending on the Lua internals, this might also improve the performance a bit. The main goal is however to reduce repetitive code, which makes it difficult to spot differences - or bugs for that matter.

How to test:

1. Sticky piston, connected with regular and vertical wires
2. Turn the piston (and wires) on and off

Or see whether the tests pass...