### PR TITLE
Check for digiline message field type

### DIFF
--- a/mesecons_detector/init.lua
+++ b/mesecons_detector/init.lua
@@ -223,10 +223,10 @@ local node_detector_digiline = {
 
 			if type(msg) == "table" then
 				if msg.distance or msg.scanname then
-					if msg.distance then
+					if msg.distance and type(msg.distance) == "string" then
 						meta:set_string("distance", msg.distance)
 					end
-					if msg.scanname then
+					if msg.scanname and type(msg.scanname) == "string" then
 						meta:set_string("scanname", msg.scanname)
 					end
 					node_detector_make_formspec(pos)
@@ -240,7 +240,7 @@ local node_detector_digiline = {
 			else
 				if msg == GET_COMMAND then
 					node_detector_send_node_name(pos, node, channel, meta)
-				else
+				elseif type(msg) == "string" then
 					meta:set_string("scanname", msg)
 					node_detector_make_formspec(pos)
 				end

--- a/mesecons_detector/init.lua
+++ b/mesecons_detector/init.lua
@@ -223,10 +223,10 @@ local node_detector_digiline = {
 
 			if type(msg) == "table" then
 				if msg.distance or msg.scanname then
-					if msg.distance and type(msg.distance) == "string" then
+					if type(msg.distance) == "string" then
 						meta:set_string("distance", msg.distance)
 					end
-					if msg.scanname and type(msg.scanname) == "string" then
+					if type(msg.scanname) == "string" then
 						meta:set_string("scanname", msg.scanname)
 					end
 					node_detector_make_formspec(pos)


### PR DESCRIPTION
This PR fixes a fatal error: if a malformed digiline table is passed into a node detector, the server may crash because of a mismatched data type.

For example, this weird backtrace happened because technic is sending "malformed" tables:

```
ERROR[Main]: ServerError: AsyncErr: Lua: Runtime error from mod '??' in callback node_on_timer(): $HOME/.minetest/mods/mesecons/mesecons_detector/init.lua:63: bad argument #2 to 'set_string' (string expected, got table)
ERROR[Main]: stack traceback:
ERROR[Main]:       [C]: in function 'set_string'
ERROR[Main]:       $HOME/.minetest/mods/mesecons/mesecons_detector/init.lua:63: in function 'action'
ERROR[Main]:       $HOME/.minetest/mods/digicontrol/override.lua:45: in function 'transmit'
ERROR[Main]:       $HOME/.minetest/mods/digicontrol/override.lua:78: in function 'receptor_send'
ERROR[Main]:       ...test/mods/technic/technic/machines/switching_station.lua:112: in function <...test/mods/technic/technic/machines/switching_station.lua:87>
```