### PR TITLE
[mesecons_doors] Improve code quality and fix Voxelgarden support

### DIFF
--- a/mesecons_doors/init.lua
+++ b/mesecons_doors/init.lua
@@ -83,18 +83,18 @@ local doors_list = {
 for i=1,#doors_list do meseconify_door(doors_list[i]) end
 
 -- Trapdoor
-local function trapdoor_switch(pos, node)
-	local state = minetest.get_meta(pos):get_int("state")
-
-	if state == 1 then
-		minetest.sound_play("doors_door_close", { pos = pos, gain = 0.3, max_hear_distance = 10 }, true)
-		minetest.set_node(pos, {name="doors:trapdoor", param2 = node.param2})
-	else
-		minetest.sound_play("doors_door_open", { pos = pos, gain = 0.3, max_hear_distance = 10 }, true)
-		minetest.set_node(pos, {name="doors:trapdoor_open", param2 = node.param2})
+local function trapdoor_switch(name)
+	return function(pos, node)
+		local state = minetest.get_meta(pos):get_int("state")
+		if state == 1 then
+			minetest.sound_play("doors_door_close", { pos = pos, gain = 0.3, max_hear_distance = 10 }, true)
+			minetest.set_node(pos, {name=name, param2 = node.param2})
+		else
+			minetest.sound_play("doors_door_open", { pos = pos, gain = 0.3, max_hear_distance = 10 }, true)
+			minetest.set_node(pos, {name=name.."_open", param2 = node.param2})
+		end
+		minetest.get_meta(pos):set_int("state", state == 1 and 0 or 1)
 	end
-
-	minetest.get_meta(pos):set_int("state", state == 1 and 0 or 1)
 end
 
 local function meseconify_trapdoor(name)
@@ -119,8 +119,8 @@ local function meseconify_trapdoor(name)
 	else
 		override = {
 			mesecons = {effector = {
-				action_on = trapdoor_switch,
-				action_off = trapdoor_switch
+				action_on = trapdoor_switch(name),
+				action_off = trapdoor_switch(name)
 			}},
 		}
 	end

--- a/mesecons_doors/init.lua
+++ b/mesecons_doors/init.lua
@@ -73,11 +73,14 @@ local function meseconify_door(name)
 	end
 end
 
-meseconify_door("doors:door_wood")
-meseconify_door("doors:door_steel")
-meseconify_door("doors:door_glass")
-meseconify_door("doors:door_obsidian_glass")
-meseconify_door("xpanes:door_steel_bar")
+local doors_list = {
+	"doors:door_wood",
+	"doors:door_steel",
+	"doors:door_glass",
+	"doors:door_obsidian_glass",
+	"xpanes:door_steel_bar",
+}
+for i=1,#doors_list do meseconify_door(doors_list[i]) end
 
 -- Trapdoor
 local function trapdoor_switch(pos, node)
@@ -94,47 +97,43 @@ local function trapdoor_switch(pos, node)
 	minetest.get_meta(pos):set_int("state", state == 1 and 0 or 1)
 end
 
-if doors and doors.get then
-	local override = {
-		mesecons = {effector = {
-			action_on = function(pos)
-				local door = doors.get(pos)
-				if door then
-					door:open()
-				end
-			end,
-			action_off = function(pos)
-				local door = doors.get(pos)
-				if door then
-					door:close()
-				end
-			end,
-		}},
-	}
-	minetest.override_item("doors:trapdoor", override)
-	minetest.override_item("doors:trapdoor_open", override)
-	minetest.override_item("doors:trapdoor_steel", override)
-	minetest.override_item("doors:trapdoor_steel_open", override)
-
-	if minetest.registered_items["xpanes:trapdoor_steel_bar"] then
-		minetest.override_item("xpanes:trapdoor_steel_bar", override)
-		minetest.override_item("xpanes:trapdoor_steel_bar_open", override)
+local function meseconify_trapdoor(name)
+	local override
+	if doors and doors.get then
+		override = {
+			mesecons = {effector = {
+				action_on = function(pos)
+					local door = doors.get(pos)
+					if door then
+						door:open()
+					end
+				end,
+				action_off = function(pos)
+					local door = doors.get(pos)
+					if door then
+						door:close()
+					end
+				end,
+			}},
+		}
+	else
+		override = {
+			mesecons = {effector = {
+				action_on = trapdoor_switch,
+				action_off = trapdoor_switch
+			}},
+		}
 	end
 
-else
-	if minetest.registered_nodes["doors:trapdoor"] then
-		minetest.override_item("doors:trapdoor", {
-			mesecons = {effector = {
-				action_on = trapdoor_switch,
-				action_off = trapdoor_switch
-			}},
-		})
-
-		minetest.override_item("doors:trapdoor_open", {
-			mesecons = {effector = {
-				action_on = trapdoor_switch,
-				action_off = trapdoor_switch
-			}},
-		})
+	if minetest.registered_items[name] then
+		minetest.override_item(name, override)
+		minetest.override_item(name.."_open", override)
 	end
 end
+
+local trapdoors_list = {
+	"doors:trapdoor",
+	"doors:trapdoor_steel",
+	"xpanes:trapdoor_steel_bar"
+}
+for i=1,#trapdoors_list do meseconify_trapdoor(trapdoors_list[i]) end


### PR DESCRIPTION
The main code quality improvement here is the functionalization of code: now trapdoors are also overriden using their own function, and both `meseconify_door` and `meseconify_trapdoor` are now ran inside for loops with local lists of base node names. In the future, this could help refactor this mod entirely to not list doors manually but parse through the doors.registered_* variables, ensuring that every door works.

As a nice bonus, [Voxelgarden](https://codeberg.org/voxelgarden/voxelgarden) support is fixed, and potentially so is support for other games with exotic implementations of the doors mod. No longer are we assuming that the existence of `doors.get` means that all the trapdoors exist too; now, if the meseconify function doesn't find their definition, it just returns without crashing.

P.S. And yes, I'm the current Voxelgarden maintainer. 