### PR TITLE
Support doors and trapdoors from mods

### DIFF
--- a/mesecons_doors/init.lua
+++ b/mesecons_doors/init.lua
@@ -123,14 +123,14 @@ local function meseconify_trapdoor(name)
 end
 
 minetest.register_on_mods_loaded(function()
-		for k,_ in pairs(doors.registered_doors) do
-			if k:find("_a$") then
-				meseconify_door(k:sub(1,-3))
-			end
+	for k,_ in pairs(doors.registered_doors) do
+		if k:find("_a$") then
+			meseconify_door(k:sub(1,-3))
 		end
-		for k,_ in pairs(doors.registered_trapdoors) do
-			if not k:find("_open$") then
-				meseconify_trapdoor(k)
-			end
+	end
+	for k,_ in pairs(doors.registered_trapdoors) do
+		if not k:find("_open$") then
+			meseconify_trapdoor(k)
 		end
-	end)
+	end
+end)

--- a/mesecons_doors/init.lua
+++ b/mesecons_doors/init.lua
@@ -73,15 +73,6 @@ local function meseconify_door(name)
 	end
 end
 
-local doors_list = {
-	"doors:door_wood",
-	"doors:door_steel",
-	"doors:door_glass",
-	"doors:door_obsidian_glass",
-	"xpanes:door_steel_bar",
-}
-for i=1,#doors_list do meseconify_door(doors_list[i]) end
-
 -- Trapdoor
 local function trapdoor_switch(name)
 	return function(pos, node)
@@ -131,9 +122,15 @@ local function meseconify_trapdoor(name)
 	end
 end
 
-local trapdoors_list = {
-	"doors:trapdoor",
-	"doors:trapdoor_steel",
-	"xpanes:trapdoor_steel_bar"
-}
-for i=1,#trapdoors_list do meseconify_trapdoor(trapdoors_list[i]) end
+minetest.register_on_mods_loaded(function()
+		for k,_ in pairs(doors.registered_doors) do
+			if k:find("_a$") then
+				meseconify_door(k:sub(1,-3))
+			end
+		end
+		for k,_ in pairs(doors.registered_trapdoors) do
+			if not k:find("_open$") then
+				meseconify_trapdoor(k)
+			end
+		end
+	end)


### PR DESCRIPTION
Removed hardcoded door names and instead now use the API of the door mod to meseconify all doors and trapdoors that have been registered after the mods are finished loading.