### PR TITLE
Limit chatcommand parameter length in command blocks

### DIFF
--- a/mesecons_commandblock/init.lua
+++ b/mesecons_commandblock/init.lua
@@ -158,8 +158,8 @@ local function commandblock_action_on(pos, node)
 			return
 		end
 		if #param > param_maxlen then
-			minetest.chat_send_player(owner, "Command parameters can only be " ..
-				param_maxlen .. " bytes long")
+			minetest.chat_send_player(owner, "Command parameters are limited to max. " ..
+				param_maxlen .. " bytes.")
 			return
 		end
 		local has_privs, missing_privs = minetest.check_player_privs(owner, cmddef.privs)

--- a/mesecons_commandblock/init.lua
+++ b/mesecons_commandblock/init.lua
@@ -1,4 +1,5 @@
 local S = minetest.get_translator(minetest.get_current_modname())
+local param_maxlen = mesecon.setting("commandblock_param_maxlen", 10000)
 
 minetest.register_chatcommand("say", {
 	params = "<text>",
@@ -154,6 +155,11 @@ local function commandblock_action_on(pos, node)
 		local cmddef = minetest.chatcommands[cmd]
 		if not cmddef then
 			minetest.chat_send_player(owner, "The command "..cmd.." does not exist")
+			return
+		end
+		if #param > param_maxlen then
+			minetest.chat_send_player(owner, "Command parameters can only be " ..
+				param_maxlen .. " bytes long")
 			return
 		end
 		local has_privs, missing_privs = minetest.check_player_privs(owner, cmddef.privs)

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -11,6 +11,11 @@ mesecon.cooldown_granularity (Cooldown step length) float 0.5 0.0 1.0
 mesecon.blinky_plant_interval (Plant blinking interval) int 3 1 5
 
 
+[mesecons_commandblock]
+
+mesecon.commandblock_param_maxlen (Maximum command parameter length) int 10000 100 1000000
+
+
 [mesecons_detector]
 
 mesecon.detector_radius (Player detector scanning radius) int 6 3 16


### PR DESCRIPTION
This PR adds a configurable maximum length for chatcommand parameters. Long parameters can possibly be used to cause crashes and other problems since mods don't expect parameters to be very long.

Hopefully the default of 10,000 bytes won't break any existing command blocks.

This issue this PR aims to fix somewhat mitigated by the formspec input length limit and https://github.com/minetest/minetest/commit/9c9309cdbb053598aaf08506928a4824e78b4622 (introduced in 5.7.0), however other mods (like [irc](https://github.com/minetest-mods/irc/pull/53)) don't have a message size limit, though a 10 kB message will probably do just as much harm, server owners would have to configure the limit if they can live with some command blocks no longer working.