### PR TITLE
Make the detector recipe from luacontroller optional

### DIFF
--- a/mesecons_detector/init.lua
+++ b/mesecons_detector/init.lua
@@ -111,14 +111,16 @@ minetest.register_node("mesecons_detector:object_detector_on", {
 	on_blast = mesecon.on_blastnode,
 })
 
-minetest.register_craft({
-	output = 'mesecons_detector:object_detector_off',
-	recipe = {
-		{"mesecons_gamecompat:steel_ingot", "mesecons_gamecompat:steel_ingot", "mesecons_gamecompat:steel_ingot"},
-		{"mesecons_gamecompat:steel_ingot", "mesecons_luacontroller:luacontroller0000", "mesecons_gamecompat:steel_ingot"},
-		{"mesecons_gamecompat:steel_ingot", "group:mesecon_conductor_craftable", "mesecons_gamecompat:steel_ingot"},
-	}
-})
+if minetest.get_modpath("mesecons_luacontroller") then
+	minetest.register_craft({
+		output = 'mesecons_detector:object_detector_off',
+		recipe = {
+			{"mesecons_gamecompat:steel_ingot", "mesecons_gamecompat:steel_ingot", "mesecons_gamecompat:steel_ingot"},
+			{"mesecons_gamecompat:steel_ingot", "mesecons_luacontroller:luacontroller0000", "mesecons_gamecompat:steel_ingot"},
+			{"mesecons_gamecompat:steel_ingot", "group:mesecon_conductor_craftable", "mesecons_gamecompat:steel_ingot"},
+		}
+	})
+end
 
 minetest.register_craft({
 	output = 'mesecons_detector:object_detector_off',
@@ -287,14 +289,16 @@ minetest.register_node("mesecons_detector:node_detector_on", {
 	on_blast = mesecon.on_blastnode,
 })
 
-minetest.register_craft({
-	output = 'mesecons_detector:node_detector_off',
-	recipe = {
-		{"mesecons_gamecompat:steel_ingot", "group:mesecon_conductor_craftable", "mesecons_gamecompat:steel_ingot"},
-		{"mesecons_gamecompat:steel_ingot", "mesecons_luacontroller:luacontroller0000", "mesecons_gamecompat:steel_ingot"},
-		{"mesecons_gamecompat:steel_ingot", "mesecons_gamecompat:steel_ingot", "mesecons_gamecompat:steel_ingot"},
-	}
-})
+if minetest.get_modpath("mesecons_luacontroller") then
+	minetest.register_craft({
+		output = 'mesecons_detector:node_detector_off',
+		recipe = {
+			{"mesecons_gamecompat:steel_ingot", "group:mesecon_conductor_craftable", "mesecons_gamecompat:steel_ingot"},
+			{"mesecons_gamecompat:steel_ingot", "mesecons_luacontroller:luacontroller0000", "mesecons_gamecompat:steel_ingot"},
+			{"mesecons_gamecompat:steel_ingot", "mesecons_gamecompat:steel_ingot", "mesecons_gamecompat:steel_ingot"},
+		}
+	})
+end
 
 minetest.register_craft({
 	output = 'mesecons_detector:node_detector_off',

--- a/mesecons_detector/mod.conf
+++ b/mesecons_detector/mod.conf
@@ -1,2 +1,3 @@
 name = mesecons_detector
 depends = mesecons, mesecons_gamecompat, mesecons_materials
+optional_depends = mesecons_luacontroller


### PR DESCRIPTION
Like in `mesecons_microcontroller` mod.
Some are hesitant to install luacontroller on their servers because of the risk of abuse.
And they don't want to have a broken recipe in craftguide.