### PR TITLE
Add missing `use_texture_alpha`

### DIFF
--- a/mesecons_extrawires/vertical.lua
+++ b/mesecons_extrawires/vertical.lua
@@ -40,6 +40,8 @@ local bottom_rules = {
 	{x=0, y=2, z=0} -- receive power from pressure plate / detector / ... 2 nodes above
 }
 
+local use_texture_alpha = minetest.features.use_texture_alpha_string_modes and "clip" or nil
+
 local function is_vertical_conductor(nodename)
 	local def = minetest.registered_nodes[nodename]
 	return def and def.is_vertical_conductor
@@ -96,7 +98,7 @@ mesecon.register_node("mesecons_extrawires:vertical", {
 	after_place_node = vertical_update,
 	after_dig_node = vertical_update,
 	sounds = mesecon.node_sound.default,
-	use_texture_alpha = "clip",
+	use_texture_alpha = use_texture_alpha,
 },{
 	tiles = {"mesecons_wire_off.png"},
 	groups = {dig_immediate=3},
@@ -131,7 +133,7 @@ mesecon.register_node("mesecons_extrawires:vertical_top", {
 	after_place_node = vertical_update,
 	after_dig_node = vertical_update,
 	sounds = mesecon.node_sound.default,
-	use_texture_alpha = "clip",
+	use_texture_alpha = use_texture_alpha,
 },{
 	tiles = {"mesecons_wire_off.png"},
 	mesecons = {conductor = {
@@ -164,7 +166,7 @@ mesecon.register_node("mesecons_extrawires:vertical_bottom", {
 	after_place_node = vertical_update,
 	after_dig_node = vertical_update,
 	sounds = mesecon.node_sound.default,
-	use_texture_alpha = "clip",
+	use_texture_alpha = use_texture_alpha,
 },{
 	tiles = {"mesecons_wire_off.png"},
 	mesecons = {conductor = {

--- a/mesecons_extrawires/vertical.lua
+++ b/mesecons_extrawires/vertical.lua
@@ -96,6 +96,7 @@ mesecon.register_node("mesecons_extrawires:vertical", {
 	after_place_node = vertical_update,
 	after_dig_node = vertical_update,
 	sounds = mesecon.node_sound.default,
+	use_texture_alpha = "clip",
 },{
 	tiles = {"mesecons_wire_off.png"},
 	groups = {dig_immediate=3},
@@ -130,6 +131,7 @@ mesecon.register_node("mesecons_extrawires:vertical_top", {
 	after_place_node = vertical_update,
 	after_dig_node = vertical_update,
 	sounds = mesecon.node_sound.default,
+	use_texture_alpha = "clip",
 },{
 	tiles = {"mesecons_wire_off.png"},
 	mesecons = {conductor = {
@@ -162,6 +164,7 @@ mesecon.register_node("mesecons_extrawires:vertical_bottom", {
 	after_place_node = vertical_update,
 	after_dig_node = vertical_update,
 	sounds = mesecon.node_sound.default,
+	use_texture_alpha = "clip",
 },{
 	tiles = {"mesecons_wire_off.png"},
 	mesecons = {conductor = {

--- a/mesecons_receiver/init.lua
+++ b/mesecons_receiver/init.lua
@@ -30,6 +30,8 @@ local receiver_get_rules = mesecon.horiz_rules_getter({
 	{x = 0, y = 0, z = -2},
 })
 
+local use_texture_alpha = minetest.features.use_texture_alpha_string_modes and "clip" or nil
+
 mesecon.register_node("mesecons_receiver:receiver", {
 	drawtype = "nodebox",
 	paramtype = "light",
@@ -98,7 +100,7 @@ mesecon.register_node("mesecons_receiver:receiver_up", {
 	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
 	drop = "mesecons:wire_00000000_off",
 	sounds = mesecon.node_sound.default,
-	use_texture_alpha = "clip",
+	use_texture_alpha = use_texture_alpha,
 }, {
 	tiles = {"mesecons_wire_off.png"},
 	mesecons = {conductor = {
@@ -144,7 +146,7 @@ mesecon.register_node("mesecons_receiver:receiver_down", {
 	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
 	drop = "mesecons:wire_00000000_off",
 	sounds = mesecon.node_sound.default,
-	use_texture_alpha = "clip",
+	use_texture_alpha = use_texture_alpha,
 }, {
 	tiles = {"mesecons_wire_off.png"},
 	mesecons = {conductor = {

--- a/mesecons_receiver/init.lua
+++ b/mesecons_receiver/init.lua
@@ -98,6 +98,7 @@ mesecon.register_node("mesecons_receiver:receiver_up", {
 	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
 	drop = "mesecons:wire_00000000_off",
 	sounds = mesecon.node_sound.default,
+	use_texture_alpha = "clip",
 }, {
 	tiles = {"mesecons_wire_off.png"},
 	mesecons = {conductor = {
@@ -143,6 +144,7 @@ mesecon.register_node("mesecons_receiver:receiver_down", {
 	groups = {dig_immediate = 3, not_in_creative_inventory = 1},
 	drop = "mesecons:wire_00000000_off",
 	sounds = mesecon.node_sound.default,
+	use_texture_alpha = "clip",
 }, {
 	tiles = {"mesecons_wire_off.png"},
 	mesecons = {conductor = {


### PR DESCRIPTION
Seems like the warnings should be more explicit. They can be overlooked for years...