### PR TITLE
Fix mesecons_gamecompat mvps hardcoding issues

### DIFF
--- a/mesecons_gamecompat/compat_mcl.lua
+++ b/mesecons_gamecompat/compat_mcl.lua
@@ -41,3 +41,16 @@ end
 -- Textures
 
 mesecon.texture.steel_block = "default_steel_block.png"
+
+if minetest.get_modpath("mesecons_mvps") then
+	core.register_on_mods_loaded(function()
+		for _,v in pairs(core.registered_nodes) do
+			if v.groups and v.groups.bed then
+				mesecon.register_mvps_stopper(v.name)
+			end
+			if v.groups and v.groups.door then
+				mesecon.register_mvps_stopper(v.name)
+			end
+		end
+	end)
+end

--- a/mesecons_gamecompat/compat_mtg.lua
+++ b/mesecons_gamecompat/compat_mtg.lua
@@ -48,28 +48,22 @@ if minetest.get_modpath("mesecons_mvps") then
 	for _, name in ipairs({
 		"default:chest_locked",
 		"default:chest_locked_open",
-		"doors:door_steel_b_1", -- old style doors
-		"doors:door_steel_b_2", --
-		"doors:door_steel_t_1", --
-		"doors:door_steel_t_2", --
-		"doors:door_steel_a",   -- new style doors
-		"doors:door_steel_b",   --
-		"doors:door_steel_c",   --
-		"doors:door_steel_d",   --
 		"doors:hidden",
-		"doors:trapdoor_steel",
-		"doors:trapdoor_steel_open",
-		"beds:bed_bottom",
-		"beds:bed_top",
-		"beds:fancy_bed_bottom",
-		"beds:fancy_bed_top",
-		"xpanes:door_steel_bar_a",
-		"xpanes:door_steel_bar_b",
-		"xpanes:door_steel_bar_c",
-		"xpanes:door_steel_bar_d",
-		"xpanes:trapdoor_steel_bar",
-		"xpanes:trapdoor_steel_bar_open",
 	}) do
 		mesecon.register_mvps_stopper(name)
 	end
+	core.register_on_mods_loaded(function()
+		if minetest.get_modpath("doors") then
+			for k,_ in pairs(doors.registered_doors) do
+				mesecon.register_mvps_stopper(k)
+			end
+		end
+		if minetest.get_modpath("beds") then
+			for _,v in pairs(core.registered_nodes) do
+				if v.groups and v.groups.bed then
+					mesecon.register_mvps_stopper(v.name)
+				end
+			end
+		end
+	end)
 end

--- a/mesecons_gamecompat/mod.conf
+++ b/mesecons_gamecompat/mod.conf
@@ -1,3 +1,3 @@
 name = mesecons_gamecompat
 depends = mesecons
-optional_depends = fire, default, dye, mesecons_mvps, tnt, mcl_fire, mcl_core, mcl_dye, mcl_tnt
+optional_depends = fire, default, dye, mesecons_mvps, tnt, doors, beds, mcl_fire, mcl_core, mcl_dye, mcl_tnt


### PR DESCRIPTION
Fixes #699
Registers mvps stoppers for all door and bed nodes registered using beds, mcl_beds, doors, mcl_doors mods.
In mtg trapdoors have the group door and need to be obtained through the api while beds don't have a registered_beds and need to be detected by their group.
In mcl_doors, doors and trapdoors have separate groups and no mcl_doors.registered_doors table.
The wooden trapdoor was not an mvps stopper, so I removed the other trapdoors from being mvps stoppers for no reason.