### PR TITLE
Support for Hades Revisited.

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -30,6 +30,7 @@ read_globals = {
 	"VoxelArea",
 	"mcl_dyes",
 	"mcl_sounds",
+	"hades_sounds",
 }
 
 globals = {"mesecon"}

--- a/mesecons_gamecompat/compat_hades.lua
+++ b/mesecons_gamecompat/compat_hades.lua
@@ -17,7 +17,7 @@ core.register_alias("mesecons_gamecompat:torch", "hades_torches:torch")
 
 if core.get_modpath("hades_dye") then
 	for _, color in ipairs(mesecon.dye_colors) do
-		core.register_alias("mesecons_gamecompat:dye_" .. color, "dye:" .. color)
+		core.register_alias("mesecons_gamecompat:dye_" .. color, "hades_dye:" .. color)
 	end
 end
 
@@ -44,7 +44,7 @@ mesecon.texture.steel_block = "default_steel_block.png"
 -- MVPS stoppers
 
 if core.get_modpath("mesecons_mvps") then
-	-- All of the locked and internal nodes in Minetest Game
+	-- All of the locked and internal nodes in Hades Revisited
 	for _, name in ipairs({
 		"hades_chests:chest_locked",
 		"hades_chests:chest_locked_open",

--- a/mesecons_gamecompat/compat_hades.lua
+++ b/mesecons_gamecompat/compat_hades.lua
@@ -1,0 +1,72 @@
+--Aliases
+
+core.register_alias("mesecons_gamecompat:chest", "hades_chests:chest")
+core.register_alias("mesecons_gamecompat:chest_locked", "hades_chests:chest_locked")
+core.register_alias("mesecons_gamecompat:coalblock", "hades_core:coalblock")
+core.register_alias("mesecons_gamecompat:cobble", "hades_core:cobble")
+core.register_alias("mesecons_gamecompat:glass", "hades_core:glass")
+core.register_alias("mesecons_gamecompat:lava_source", "hades_core:lava_source")
+core.register_alias("mesecons_gamecompat:mese", "hades_core:mese")
+core.register_alias("mesecons_gamecompat:mese_crystal", "hades_core:mese_crystal")
+core.register_alias("mesecons_gamecompat:mese_crystal_fragment", "hades_core:mese_crystal_fragment")
+core.register_alias("mesecons_gamecompat:obsidian_glass", "hades_core:obsidian_glass")
+core.register_alias("mesecons_gamecompat:stone", "hades_core:stone")
+core.register_alias("mesecons_gamecompat:steel_ingot", "hades_core:steel_ingot")
+core.register_alias("mesecons_gamecompat:steelblock", "hades_core:steelblock")
+core.register_alias("mesecons_gamecompat:torch", "hades_torches:torch")
+
+if core.get_modpath("hades_dye") then
+	for _, color in ipairs(mesecon.dye_colors) do
+		core.register_alias("mesecons_gamecompat:dye_" .. color, "dye:" .. color)
+	end
+end
+
+-- Sounds
+
+mesecon.node_sound.default = hades_sounds.node_sound_defaults()
+mesecon.node_sound.glass = hades_sounds.node_sound_glass_defaults()
+mesecon.node_sound.leaves = hades_sounds.node_sound_leaves_defaults()
+mesecon.node_sound.stone = hades_sounds.node_sound_stone_defaults()
+mesecon.node_sound.wood = hades_sounds.node_sound_wood_defaults()
+
+if core.get_modpath("hades_fire") then
+	mesecon.sound_name.fire = "fire_fire"
+end
+
+if core.get_modpath("hades_tnt") then
+	mesecon.sound_name.explode = "tnt_explode"
+end
+
+-- Textures
+
+mesecon.texture.steel_block = "default_steel_block.png"
+
+-- MVPS stoppers
+
+if core.get_modpath("mesecons_mvps") then
+	-- All of the locked and internal nodes in Minetest Game
+	for _, name in ipairs({
+		"hades_chests:chest_locked",
+		"hades_chests:chest_locked_open",
+		"hades_doors:hidden",
+		"hades_doors:hidden_center",
+	}) do
+		mesecon.register_mvps_stopper(name)
+	end
+	core.register_on_mods_loaded(function()
+		if core.get_modpath("hades_doors") then
+			for _,v in pairs(core.registered_nodes) do
+				if v.groups and (v.groups.door or v.groups.trapdoor) then
+					mesecon.register_mvps_stopper(v.name)
+				end
+			end
+		end
+		if core.get_modpath("hades_beds") then
+			for _,v in pairs(core.registered_nodes) do
+				if v.groups and v.groups.bed then
+					mesecon.register_mvps_stopper(v.name)
+				end
+			end
+		end
+	end)
+end

--- a/mesecons_gamecompat/init.lua
+++ b/mesecons_gamecompat/init.lua
@@ -19,6 +19,11 @@ if minetest.get_modpath("mcl_redstone") then
 	dofile(minetest.get_modpath("mesecons_gamecompat").."/compat_mcla.lua")
 end
 
+if minetest.get_modpath("hades_core") then
+	minetest.log("info", "Mesecons: detected Hades Revisited Game for game compatibility")
+	dofile(minetest.get_modpath("mesecons_gamecompat").."/compat_hades.lua")
+end
+
 if minetest.get_modpath("doors") then
 	dofile(minetest.get_modpath("mesecons_gamecompat").."/doors.lua")
 end

--- a/mesecons_gamecompat/mod.conf
+++ b/mesecons_gamecompat/mod.conf
@@ -1,3 +1,3 @@
 name = mesecons_gamecompat
 depends = mesecons
-optional_depends = fire, default, dye, mesecons_mvps, tnt, doors, beds, mcl_fire, mcl_core, mcl_dye, mcl_tnt
+optional_depends = fire, default, dye, mesecons_mvps, tnt, doors, beds, mcl_fire, mcl_core, mcl_dye, mcl_tnt, hades_core, hades_sounds, hades_torches, hades_doors, hades_beds, hades_fire, hades_tnt

--- a/mesecons_gamecompat/mod.conf
+++ b/mesecons_gamecompat/mod.conf
@@ -1,3 +1,3 @@
 name = mesecons_gamecompat
 depends = mesecons
-optional_depends = fire, default, dye, mesecons_mvps, tnt, doors, beds, mcl_fire, mcl_core, mcl_dye, mcl_tnt, hades_core, hades_sounds, hades_torches, hades_doors, hades_beds, hades_fire, hades_tnt
+optional_depends = fire, default, dye, mesecons_mvps, tnt, doors, beds, mcl_fire, mcl_core, mcl_dye, mcl_tnt, hades_sounds


### PR DESCRIPTION
Integrate support for Hades Revisited into the Mesecons modpack, allowing it to tag https://content.luanti.org/packages/SFENCE/hades_mesecons/ as obsolete.