### PR TITLE
siliconless gate recipes

### DIFF
--- a/mesecons_gates/init.lua
+++ b/mesecons_gates/init.lua
@@ -183,3 +183,32 @@ register_gate("or", 2, function (val1, val2) return (val1 or val2) end,
 	 {"", "mesecons:mesecon", "mesecons:mesecon"},
 	 {"mesecons:mesecon", "", ""}},
 	S("OR Gate"))
+
+-- alternate gate recipes without silicon
+
+core.register_craft({
+		output = "mesecons_gates:and",
+		recipe = {
+			{"mesecons_torch:mesecon_torch_on", ""                , ""                               },
+			{""                               , "mesecons:mesecon", "mesecons_torch:mesecon_torch_on"},
+			{"mesecons_torch:mesecon_torch_on", ""                , ""                               },
+		},
+})
+
+core.register_craft({
+		output = "mesecons_gates:nand",
+		recipe = {
+			{"mesecons_torch:mesecon_torch_on", ""                , ""                },
+			{""                               , "mesecons:mesecon", "mesecons:mesecon"},
+			{"mesecons_torch:mesecon_torch_on", ""                , ""                },
+		},
+})
+
+core.register_craft({
+		output = "mesecons_gates:xor",
+		recipe = {
+			{"mesecons_torch:mesecon_torch_on", "mesecons:mesecon"               , "mesecons_torch:mesecon_torch_on"},
+			{"mesecons:mesecon"               , "mesecons_torch:mesecon_torch_on", "mesecons:mesecon"               },
+			{"mesecons_torch:mesecon_torch_on", "mesecons:mesecon"               , "mesecons_torch:mesecon_torch_on"},
+		},
+})


### PR DESCRIPTION
surprisingly enough, the 3² grid is just big enough to fit an xor gate

"Add alternate gate recipes without silicon

Added alternate crafting recipes for AND, NAND, and XOR gates without silicon." - copilot