### PR TITLE
futureproof luacontrollers against additional arguments in on_construct

### DIFF
--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -812,6 +812,10 @@ local function set_program(pos, code)
 	return run(pos, {type="program"})
 end
 
+on_construct = function(pos)
+	reset_meta(pos)
+end
+
 local function on_receive_fields(pos, _, fields, sender)
 	if not fields.program then
 		return
@@ -908,7 +912,7 @@ for d = 0, 1 do
 		sunlight_propagates = true,
 		selection_box = selection_box,
 		node_box = node_box,
-		on_construct = reset_meta,
+		on_construct = on_construct,
 		on_receive_fields = on_receive_fields,
 		sounds = mesecon.node_sound.stone,
 		mesecons = mesecons,

--- a/mesecons_luacontroller/init.lua
+++ b/mesecons_luacontroller/init.lua
@@ -812,7 +812,7 @@ local function set_program(pos, code)
 	return run(pos, {type="program"})
 end
 
-on_construct = function(pos)
+local function on_construct(pos)
 	reset_meta(pos)
 end
 


### PR DESCRIPTION
currently, if an additional argument is added to  `on_construct`, the `reset_meta` function will interpret it as code and fail