### PR TITLE
Add 'disable_door_override' setting

### DIFF
--- a/mesecons_gamecompat/init.lua
+++ b/mesecons_gamecompat/init.lua
@@ -24,6 +24,7 @@ if minetest.get_modpath("hades_core") then
 	dofile(minetest.get_modpath("mesecons_gamecompat").."/compat_hades.lua")
 end
 
-if minetest.get_modpath("doors") then
+if minetest.get_modpath("doors") and
+		not core.settings:get_bool("mesecon.disable_door_override") then
 	dofile(minetest.get_modpath("mesecons_gamecompat").."/doors.lua")
 end

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -65,3 +65,7 @@ mesecon.piston_max_pull (Max pull) int 15 1 100
 [mesecons_pressureplates]
 
 mesecon.pplate_interval (Check interval) float 0.1 0.1 1.0
+
+[mesecons_gamecompat]
+
+mesecon.disable_door_override (Disable door override) bool false


### PR DESCRIPTION
This adds a 'mesecon.disable_door_override' setting to stop mesecon_gamecompat from overriding all registered doors which can break some 3rd party mods.

Note: This use to be a 'mesecon_doors' mod that could be easily disabled.